### PR TITLE
chore: add commands to list and delete event source mappings

### DIFF
--- a/pkg/resource/aws/aws_lambda_event_source_mapping_test.go
+++ b/pkg/resource/aws/aws_lambda_event_source_mapping_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/snyk/driftctl/test/acceptance"
 )
 
+// aws lambda list-event-source-mappings to list all event source mappings
+// aws lambda delete-event-source-mapping --uuid xxx to delete a specific event source mapping
+
 func TestAcc_AwsLambdaEventSourceMapping(t *testing.T) {
 	acceptance.Run(t, acceptance.AccTestCase{
 		TerraformVersion: "0.15.5",


### PR DESCRIPTION
For QA purposes, if event source mappings are yet to be deleted but not found in the console you can still use CLI commands. This PR adds those commands in the test file.