### PR TITLE
Revert "chore: add licensing acknowledgments"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,15 +6,9 @@ release:
         name: driftctl
     draft: false
     prerelease: auto
-    extra_files:
-        - glob: ./acknowledgements.tar.gz
 before:
     hooks:
         - go generate ./...
-        - go install github.com/google/go-licenses@latest
-        - go-licenses save . --save_path=./acknowledgements
-        - tar -cvf ./acknowledgements.tar.gz -C ./acknowledgements .
-        - rm -rf ./acknowledgements
 signs:
     - signature: "${artifact}.gpg"
       artifacts: checksum


### PR DESCRIPTION
Let's disable this since it break release builds because of an issue with azure sdk (again and always ...)

```
one or more libraries have an incompatible/unknown license: map["unknown":["github.com/Azure/azure-sdk-for-go/sdk/internal/log" "github.com/Azure/azure-sdk-for-go/sdk/internal/diag" "github.com/Azure/azure-sdk-for-go/sdk/internal/errorinfo" "github.com/Azure/azure-sdk-for-go/sdk/internal/uuid"]]
```

This reverts commit caabac2bee7e5c1e6cd1b93086aed611634090b9.
