### PR TITLE
Add custom changelog to goreleaser command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@
 
 ### driftctl
 /.driftignore
+
+CHANGELOG.md

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,11 @@ if [ "$CI" != true ]; then
     FLAGS+="--snapshot "
 fi
 
+if [ "$CI" == true ] && [ "$CMD" == "release" ]; then
+    ./scripts/changelog.sh > CHANGELOG.md
+    FLAGS+="--release-notes CHANGELOG.md "
+fi
+
 CMD="goreleaser ${CMD} ${FLAGS}"
 
 echo "+ Building using goreleaser"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -25,34 +25,26 @@ fi
 # Keep IDs of merged pull requests
 PRs=$(git log --pretty=oneline $BASE...$LATEST_TAG | grep 'Merge pull request #' | grep -oP '#[0-9]+' | sed 's/#//')
 
-echo "Generating changelog for commits from $BASE to $LATEST_TAG..."
-
+# Generating changelog for commits from $BASE to $LATEST_TAG
 CHANGES=()
 for pr in $PRs; do
     str=$($GHCLI_BIN pr view $pr --repo $REPO -t '- {{ .title }} (#{{ .number }}) @{{ .author.login }} {{.labels}}' --json title,number,author,labels)
     CHANGES+=("$str")
 done
 
-echo -e "\n## 🚀 Enhancements\n"
-
-for change in "${CHANGES[@]}"; do
-    if [[ $change =~ "kind/enhancement" ]]; then
-        echo $change | sed "s/\[map\[$PARTITION_COLUMN.*//"
+print_changes() {
+    local label=$1
+    local title=$2
+    if [[ "${CHANGES[@]}" =~ $label ]]; then
+        echo -e $title
+        for change in "${CHANGES[@]}"; do
+            if [[ $change =~ $label ]]; then
+                echo $change | sed "s/\[map\[$PARTITION_COLUMN.*//"
+            fi
+        done
     fi
-done
+}
 
-echo -e "\n## 🐛 Bug Fixes\n"
-
-for change in "${CHANGES[@]}"; do
-    if [[ $change =~ "kind/bug" ]]; then
-        echo $change | sed "s/\[map\[$PARTITION_COLUMN.*//"
-    fi
-done
-
-echo -e "\n## 🔨 Maintenance\n"
-
-for change in "${CHANGES[@]}"; do
-    if [[ $change =~ "kind/maintenance" ]]; then
-        echo $change | sed "s/\[map\[$PARTITION_COLUMN.*//"
-    fi
-done
+print_changes "kind/enhancement" "## 🚀 Enhancements"
+print_changes "kind/bug" "## 🐛 Bug Fixes"
+print_changes "kind/maintenance" "## 🔨 Maintenance"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

As we now want to release early and often, this PR updates the goreleaser config in order to write the release changelog automatically. I also edited the actual changelog generator script, code was slightly simplified and it doesn't add empty changelog sections anymore. CHANGELOG.md was added to the gitignore file so the git state doesn't get dirty when releasing (goreleaser doesn't like that).

Output example: 

**Before**:

```shell
$ GITHUB_TOKEN=<redacted> ./scripts/changelog.sh
Generating changelog for commits from origin/HEAD to v0.18.1...

## 🚀 Enhancements


## 🐛 Bug Fixes

- Fix google_compute_subnetwork attributes (#1293) @sundowndev 

## 🔨 Maintenance

- Use docker executor for tests (#1294) @eliecharra 
- Improve testing for the GCS backend (#1292) @sundowndev 
- User large circleci executors (#1291) @eliecharra 
```

**After**:

```shell
$ GITHUB_TOKEN=<redacted> ./scripts/changelog.sh
## 🐛 Bug Fixes
- Fix google_compute_subnetwork attributes (#1293) @sundowndev 
## 🔨 Maintenance
- Use docker executor for tests (#1294) @eliecharra 
- Improve testing for the GCS backend (#1292) @sundowndev 
- User large circleci executors (#1291) @eliecharra
```