### PR TITLE
Add missing circleci context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,6 +258,7 @@ workflows:
               ignore: /.*/
       - release:
           context:
+              - driftctl
               - driftctl-snyk
               - driftctl-signing
           requires:


### PR DESCRIPTION
This context contain the GITHUB_TOKEN env var needed to publish a new release. We previously used this context but for some reason we dropped it when moving from cloudskiff to snyk.