### PR TITLE
Fix google_compute_network read attributes

### DIFF
--- a/pkg/remote/google/google_compute_network_enumerator.go
+++ b/pkg/remote/google/google_compute_network_enumerator.go
@@ -38,7 +38,7 @@ func (e *GoogleComputeNetworkEnumerator) Enumerate() ([]*resource.Resource, erro
 				string(e.SupportedType()),
 				trimResourceName(res.GetName()),
 				map[string]interface{}{
-					"display_name": res.DisplayName,
+					"name": res.DisplayName,
 				},
 			),
 		)

--- a/pkg/resource/google/google_compute_network.go
+++ b/pkg/resource/google/google_compute_network.go
@@ -13,7 +13,7 @@ func initGoogleComputeNetworkMetadata(resourceSchemaRepository resource.SchemaRe
 	})
 	resourceSchemaRepository.SetResolveReadAttributesFunc(GoogleComputeNetworkResourceType, func(res *resource.Resource) map[string]string {
 		return map[string]string{
-			"name": *res.Attributes().GetString("display_name"),
+			"name": *res.Attributes().GetString("name"),
 		}
 	})
 	resourceSchemaRepository.SetFlags(GoogleComputeNetworkResourceType, resource.FlagDeepMode)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

A recent acceptance test run catched this bug where attributes from the `google_compute_network` enumerator doesn't match the Terraform schema of the resource.

See https://app.circleci.com/pipelines/github/snyk/driftctl/3961/workflows/b530585a-c6d4-4cf2-8f22-159fbf672d84/jobs/8157