### PR TITLE
User large circleci executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
     parameters:
       pattern:
         type: string
+    resource_class: large
     machine:
       image: ubuntu-2004:202010-01
     environment:
@@ -75,6 +76,7 @@ jobs:
       - run: make install-tools
       - run: make lint
   test:
+    resource_class: large
     machine:
       image: ubuntu-2004:202107-02
     steps:
@@ -92,6 +94,7 @@ jobs:
       - store_test_results:
           path: ./
   release:
+    resource_class: large
     docker:
       - image: golang:1.16
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ only_maintainers: &only_maintainers
       # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
       ignore: /pull\/[0-9]+/
 orbs:
-  go: circleci/go@1.5.0
+  go: circleci/go@1.7.0
   codecov: codecov/codecov@3.1.0
   snyk: snyk/snyk@1.1.2
 jobs:
@@ -32,8 +32,6 @@ jobs:
       - checkout
       - go/install:
           version: "1.16.2"
-          # Disable cache at it seem to broke go 1.16 installation
-          cache: false
       - run: make install-tools
       - run:
           name: Setup Google credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
       - checkout
       - go/install:
           version: "1.16.2"
+      - go/load-cache:
+          key: test_acc
       - run: make install-tools
       - run:
           name: Setup Google credentials
@@ -53,6 +55,9 @@ jobs:
               -H "Content-Type: application/json" \
               -d "{\"content\": \"❌ Acceptance tests failed\nSuite: ${ACC_PATTERN}\n<${CIRCLE_BUILD_URL}>\" }"\
               ${DISCORD_WEBHOOK}
+      - go/save-cache:
+          key: test_acc
+          path: /home/circleci/.go_workspace/pkg/mod
       - store_test_results:
           path: ./
   lint:
@@ -79,14 +84,17 @@ jobs:
       image: ubuntu-2004:202107-02
     steps:
       - checkout
+      - go/install:
+          version: "1.16.2"
+      - go/load-cache:
+          key: test
+      - run: make install-tools
       - run:
           name: Run tests
-          command: |
-            docker run\
-              -v$(pwd):/app\
-              -w /app\
-              golang:1.16\
-              bash -c 'make install-tools && make test'
+          command: make test
+      - go/save-cache:
+          key: test
+          path: /home/circleci/.go_workspace/pkg/mod
       - codecov/upload:
           flags: unit
       - store_test_results:


### PR DESCRIPTION
## Description

This PR goal is to speed-up test check in PRs

- Use larger circleci executors
- Update circleci/go orb: allow us to reuse go binary cache
- Add go mod caching

**Before**
![image](https://user-images.githubusercontent.com/6154987/146373566-fdb88977-5ae5-4b23-9f74-37d69e7c360d.png)

**After**
![image](https://user-images.githubusercontent.com/6154987/146374118-b867d642-6f74-4a30-ba15-9c26b04a9abd.png)
