### PR TITLE
Improve testing for the GCS backend

### DIFF
--- a/pkg/iac/terraform/state/backend/testdata/gcp_application_default_credentials.json
+++ b/pkg/iac/terraform/state/backend/testdata/gcp_application_default_credentials.json
@@ -1,7 +1,0 @@
-{
-  "client_id": "testdata.driftctl.apps.googleusercontent.com",
-  "client_secret": "fake-secret",
-  "quota_project_id": "fake-project-id",
-  "refresh_token": "fake-token",
-  "type": "authorized_user"
-}


### PR DESCRIPTION
## Description

Following https://github.com/snyk/driftctl/pull/1282#issuecomment-995863330, we shouldn't perform any IO/network operations in a constructor. This PR improves testing of the GCS backend: we never use the non-mocked storage client in tests to avoid IO/network operations. In a real world execution, the storage client is created in the `Read` method.