### PR TITLE
 Fix google_compute_subnetwork attributes

### DIFF
--- a/pkg/remote/google/google_compute_subnetwork_enumerator.go
+++ b/pkg/remote/google/google_compute_subnetwork_enumerator.go
@@ -38,8 +38,8 @@ func (e *GoogleComputeSubnetworkEnumerator) Enumerate() ([]*resource.Resource, e
 				string(e.SupportedType()),
 				trimResourceName(res.GetName()),
 				map[string]interface{}{
-					"name":     res.GetDisplayName(),
-					"location": res.GetLocation(),
+					"name":   res.GetDisplayName(),
+					"region": res.GetLocation(),
 				},
 			),
 		)

--- a/pkg/resource/google/google_compute_subnetwork.go
+++ b/pkg/resource/google/google_compute_subnetwork.go
@@ -8,7 +8,7 @@ func initGoogleComputeSubnetworkMetadata(resourceSchemaRepository resource.Schem
 	resourceSchemaRepository.SetResolveReadAttributesFunc(GoogleComputeSubnetworkResourceType, func(res *resource.Resource) map[string]string {
 		return map[string]string{
 			"name":   *res.Attributes().GetString("name"),
-			"region": *res.Attributes().GetString("location"),
+			"region": *res.Attributes().GetString("region"),
 		}
 	})
 	resourceSchemaRepository.SetNormalizeFunc(GoogleComputeSubnetworkResourceType, func(res *resource.Resource) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description
Just like #1290, https://github.com/snyk/driftctl/pull/1197

A recent acceptance test run catched this bug where attributes from the google_compute_subnetwork enumerator doesn't match the Terraform schema of the resource.

See https://app.circleci.com/pipelines/github/snyk/driftctl/3979/workflows/91c85c7e-7362-4497-b41f-98ac8397c194/jobs/8231