### PR TITLE
Use docker executor for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,21 +80,19 @@ jobs:
       - run: make lint
   test:
     resource_class: large
-    machine:
-      image: ubuntu-2004:202107-02
+    executor:
+        name: go/default
+        tag: '1.16.2'
     steps:
       - checkout
-      - go/install:
-          version: "1.16.2"
       - go/load-cache:
-          key: test
+          key: test-docker
       - run: make install-tools
       - run:
           name: Run tests
           command: make test
       - go/save-cache:
-          key: test
-          path: /home/circleci/.go_workspace/pkg/mod
+          key: test-docker
       - codecov/upload:
           flags: unit
       - store_test_results:


### PR DESCRIPTION
## Description

Reduce the time of test.
We want to keep the machine executor for acc tests since they are more heavy.

**Before**
![image](https://user-images.githubusercontent.com/6154987/146523945-037935e1-ae37-4018-aae0-6a662002bfca.png)


**After**
![image](https://user-images.githubusercontent.com/6154987/146523872-64667bb7-2b13-438b-8031-02a7317f3d84.png)
