### PR TITLE
Update goreleaser config & version

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,7 +7,7 @@ set -eo pipefail
 
 if ! which goreleaser >/dev/null; then
     echo "+ Installing goreleaser..."
-    go install github.com/goreleaser/goreleaser@v0.173.2
+    go install github.com/goreleaser/goreleaser@v1.1.0
 fi
 
 export ENV="${ENV:-dev}"
@@ -40,7 +40,9 @@ if [ "$CI" != true ]; then
 fi
 
 if [ "$CI" == true ] && [ "$CMD" == "release" ]; then
+    echo "Generating changelog..."
     ./scripts/changelog.sh > CHANGELOG.md
+    cat CHANGELOG.md
     FLAGS+="--release-notes CHANGELOG.md "
 fi
 


### PR DESCRIPTION
## Description

The last release failed to use the proper release notes. The generated changelog will now be showed in the logs. Also bump goreleaser version to v1.1.0.

In the meantime, I've opened https://github.com/goreleaser/goreleaser/issues/2778 to ensure it's not a bug from goreleaser.
