### PR TITLE
Use second most recent tag in changelog script

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
+# This script compare merged pull requests between the two most recent tags
 # Please note that this script only work with Github repositories.
 # Prerequisites: git, github cli
 
 GHCLI_BIN="gh"
 REPO="snyk/driftctl"
-LATEST_TAG=$(git describe --abbrev=0) # Get the least created tag
+LATEST_TAG=$(git describe --abbrev=0) # Get the last created tag
 DEFAULT_BRANCH=origin/HEAD
-BASE=$DEFAULT_BRANCH # Change this if you don't want to use the default branch as base
+BASE=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 2p) # Use $DEFAULT_BRANCH instead to get a pre-release changelog
 
 # Check GH cli is installed
 if ! which $GHCLI_BIN &> /dev/null; then


### PR DESCRIPTION
## Description

Since the tag is already created when releasing, we need to compare commits based on the second most recent tag, not the default branch. For now we just get an empty changelog so goreleaser fallback to its default changelog generator.