### PR TITLE
Fix acceptance test for google_bigquery_table

### DIFF
--- a/pkg/resource/google/google_bigquery_table_test.go
+++ b/pkg/resource/google/google_bigquery_table_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -17,6 +18,11 @@ func TestAcc_Google_BigqueryTable(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately on GCP api after an apply operation
+				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
+					return !result.IsSync() && retryDuration < time.Minute
+				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
## Description

This test failed in our nightly run but used to succeed in previous runs. I cannot reproduce locally so I suggest this is just about the resource not being visible in the API immediately, this is the case for 7 other GCP resources.