### PR TITLE
Fix acceptance test for aws_api_gateway_stage

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_api_gateway_stage/terraform.tf
@@ -47,7 +47,3 @@ resource "aws_api_gateway_stage" "foo" {
     rest_api_id   = aws_api_gateway_rest_api.foo.id
     stage_name    = "bar"
 }
-
-resource "aws_api_gateway_deployment" "bar" {
-    rest_api_id = aws_api_gateway_rest_api.foo.id
-}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

We [recently experienced this error](https://app.circleci.com/pipelines/github/snyk/driftctl/4069/workflows/ce8eabc7-3fc6-45fb-94f5-ac4d223b688a/jobs/8568) in nightly tests : 
```
=== RUN   TestAcc_Aws_ApiGatewayStage
[...]
Error: Error creating API Gateway Deployment: ConflictException: Another Deployment is in progress for rest api with id ljzdvh62d7 . Please try again later.
```

This PR attempt to fix acceptance test for resource `aws_api_gateway_stage`. I removed one of the deployment so it doesn't conflict with the other one.