### PR TITLE
Handle patch releases in changelog script

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -6,9 +6,9 @@
 
 GHCLI_BIN="gh"
 REPO="snyk/driftctl"
-LATEST_TAG=$(git describe --abbrev=0) # Get the last created tag
-DEFAULT_BRANCH=origin/HEAD
-BASE=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 2p) # Use $DEFAULT_BRANCH instead to get a pre-release changelog
+LATEST_TAG=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 1p) # Get the last created tag
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BASE=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 2p) # Use $CURRENT_BRANCH instead to get a pre-release changelog
 
 # Check GH cli is installed
 if ! which $GHCLI_BIN &> /dev/null; then


### PR DESCRIPTION
## Description

This PR improve the changelog generator script so it better handle patch releases. We were previously using tags created from the default branch (main) to analyze commit history but it doesn't work for patch releases since they're created from another branch. Those changes ensure we compare the right tags to generate the changelog.