### PR TITLE
Add aws_apigatewayv2_domain_name resource

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -115,6 +115,7 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 		middlewares.NewAwsApiGatewayApiExpander(d.resourceFactory),
 		middlewares.NewAwsApiGatewayRestApiPolicyExpander(d.resourceFactory),
 		middlewares.NewAwsConsoleApiGatewayGatewayResponse(),
+		middlewares.NewAwsApiGatewayDomainNamesReconciler(),
 
 		middlewares.NewGoogleIAMBindingTransformer(d.resourceFactory),
 		middlewares.NewGoogleIAMPolicyTransformer(d.resourceFactory),

--- a/pkg/iac/terraform/state/terraform_state_reader_test.go
+++ b/pkg/iac/terraform/state/terraform_state_reader_test.go
@@ -182,6 +182,7 @@ func TestTerraformStateReader_AWS_Resources(t *testing.T) {
 		{name: "App gateway v2 vpc link", dirName: "aws_apigatewayv2_vpc_link", wantErr: false},
 		{name: "App gateway v2 route response", dirName: "aws_apigatewayv2_route_response", wantErr: false},
 		{name: "Api Gateway V2 mapping", dirName: "aws_apigatewayv2_api_mapping", wantErr: false},
+		{name: "App gateway v2 domain name", dirName: "aws_apigatewayv2_domain_name", wantErr: false},
 		{name: "AppAutoScaling Targets", dirName: "aws_appautoscaling_target", wantErr: false},
 		{name: "network acl", dirName: "aws_network_acl", wantErr: false},
 		{name: "network acl rule", dirName: "aws_network_acl_rule", wantErr: false},

--- a/pkg/iac/terraform/state/test/aws_apigatewayv2_domain_name/results.golden.json
+++ b/pkg/iac/terraform/state/test/aws_apigatewayv2_domain_name/results.golden.json
@@ -1,0 +1,21 @@
+[
+ {
+  "Id": "driftctl.example.com",
+  "Type": "aws_apigatewayv2_domain_name",
+  "Attrs": {
+   "api_mapping_selection_expression": "$request.basepath",
+   "arn": "arn:aws:apigateway:us-east-2::/domainnames/driftctl.example.com",
+   "domain_name": "driftctl.example.com",
+   "domain_name_configuration": [
+    {
+     "certificate_arn": "arn:aws:acm:us-east-2:047081014315:certificate/c49d9c11-1308-4594-bd78-7853466ae7bc",
+     "endpoint_type": "REGIONAL",
+     "hosted_zone_id": "ZOJJZC49E0EPZ",
+     "security_policy": "TLS_1_2",
+     "target_domain_name": "d-db4yiff8oa.execute-api.us-east-2.amazonaws.com"
+    }
+   ],
+   "id": "driftctl.example.com"
+  }
+ }
+]

--- a/pkg/iac/terraform/state/test/aws_apigatewayv2_domain_name/terraform.tfstate
+++ b/pkg/iac/terraform/state/test/aws_apigatewayv2_domain_name/terraform.tfstate
@@ -1,0 +1,46 @@
+{
+  "version": 4,
+  "terraform_version": "1.1.2",
+  "serial": 14,
+  "lineage": "994eb10d-52ac-0b78-177a-e3de9a744df4",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_apigatewayv2_domain_name",
+      "name": "example",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "api_mapping_selection_expression": "$request.basepath",
+            "arn": "arn:aws:apigateway:us-east-2::/domainnames/driftctl.example.com",
+            "domain_name": "driftctl.example.com",
+            "domain_name_configuration": [
+              {
+                "certificate_arn": "arn:aws:acm:us-east-2:047081014315:certificate/c49d9c11-1308-4594-bd78-7853466ae7bc",
+                "endpoint_type": "REGIONAL",
+                "hosted_zone_id": "ZOJJZC49E0EPZ",
+                "security_policy": "TLS_1_2",
+                "target_domain_name": "d-db4yiff8oa.execute-api.us-east-2.amazonaws.com"
+              }
+            ],
+            "id": "driftctl.example.com",
+            "mutual_tls_authentication": [],
+            "tags": null,
+            "tags_all": {},
+            "timeouts": null
+          },
+          "sensitive_attributes": [],
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsInVwZGF0ZSI6MzYwMDAwMDAwMDAwMH19",
+          "dependencies": [
+            "aws_acm_certificate.example",
+            "tls_private_key.example",
+            "tls_self_signed_cert.example"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/middlewares/aws_api_gateway_domain_names_reconciler.go
+++ b/pkg/middlewares/aws_api_gateway_domain_names_reconciler.go
@@ -1,0 +1,79 @@
+package middlewares
+
+import (
+	"github.com/snyk/driftctl/pkg/resource"
+	"github.com/snyk/driftctl/pkg/resource/aws"
+)
+
+// Used to reconcile API Gateway domain names (v1 and v2) from both remote
+// and state resources because v1|v2 AWS SDK list endpoints return all domain
+// names without distinction
+type AwsApiGatewayDomainNamesReconciler struct{}
+
+func NewAwsApiGatewayDomainNamesReconciler() AwsApiGatewayDomainNamesReconciler {
+	return AwsApiGatewayDomainNamesReconciler{}
+}
+
+func (m AwsApiGatewayDomainNamesReconciler) Execute(remoteResources, resourcesFromState *[]*resource.Resource) error {
+	newRemoteResources := make([]*resource.Resource, 0)
+	managedDomainNames := make([]*resource.Resource, 0)
+	unmanagedDomainNames := make([]*resource.Resource, 0)
+	for _, res := range *remoteResources {
+		// Ignore all resources other than aws_api_gateway_domain_name and aws_apigatewayv2_domain_name
+		if res.ResourceType() != aws.AwsApiGatewayDomainNameResourceType &&
+			res.ResourceType() != aws.AwsApiGatewayV2DomainNameResourceType {
+			newRemoteResources = append(newRemoteResources, res)
+			continue
+		}
+
+		// Find a matching state resources
+		existInState := false
+		for _, stateResource := range *resourcesFromState {
+			if res.Equal(stateResource) {
+				existInState = true
+				break
+			}
+		}
+
+		// Keep track of the resource if it's managed in IaC
+		if existInState {
+			managedDomainNames = append(managedDomainNames, res)
+			continue
+		}
+
+		// If we're here, it means that we are left with unmanaged domain names
+		// in both v1 and v2 format. Let's group real and duplicate domain names
+		// in a slice
+		unmanagedDomainNames = append(unmanagedDomainNames, res)
+	}
+
+	// We only want to show to our end users unmanaged v1 domain names
+	// To do that, we're going to loop over unmanaged domain names to delete duplicates
+	// and leave after that only v1 domain names (e.g. remove v2 ones)
+	deduplicatedUnmanagedDomains := make([]*resource.Resource, 0, len(unmanagedDomainNames))
+	for _, unmanaged := range unmanagedDomainNames {
+		// Remove duplicates (e.g. same id, the opposite type)
+		isDuplicate := false
+		for _, managed := range managedDomainNames {
+			if managed.ResourceId() == unmanaged.ResourceId() {
+				isDuplicate = true
+				break
+			}
+		}
+		if isDuplicate {
+			continue
+		}
+
+		// Now keep only v1 domain names
+		if unmanaged.ResourceType() == aws.AwsApiGatewayDomainNameResourceType {
+			deduplicatedUnmanagedDomains = append(deduplicatedUnmanagedDomains, unmanaged)
+		}
+	}
+
+	// Finally, add both managed and unmanaged resources to remote resources
+	newRemoteResources = append(newRemoteResources, managedDomainNames...)
+	newRemoteResources = append(newRemoteResources, deduplicatedUnmanagedDomains...)
+
+	*remoteResources = newRemoteResources
+	return nil
+}

--- a/pkg/middlewares/aws_api_gateway_domain_names_reconciler_test.go
+++ b/pkg/middlewares/aws_api_gateway_domain_names_reconciler_test.go
@@ -1,0 +1,184 @@
+package middlewares
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/r3labs/diff/v2"
+	"github.com/snyk/driftctl/pkg/resource"
+	"github.com/snyk/driftctl/pkg/resource/aws"
+)
+
+func TestAwsApiGatewayDomainNamesReconciler_Execute(t *testing.T) {
+	tests := []struct {
+		name               string
+		resourcesFromState []*resource.Resource
+		remoteResources    []*resource.Resource
+		expected           []*resource.Resource
+	}{
+		{
+			name: "with managed resources",
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+			remoteResources: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+		},
+		{
+			name:               "with unmanaged resources",
+			resourcesFromState: []*resource.Resource{},
+			remoteResources: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+			},
+		},
+		{
+			name: "with deleted resources",
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+			remoteResources: []*resource.Resource{},
+			expected:        []*resource.Resource{},
+		},
+		{
+			name: "with a mix of managed, unmanaged and deleted resources",
+			resourcesFromState: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain4",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+			},
+			remoteResources: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain3",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain3",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+			},
+			expected: []*resource.Resource{
+				{
+					Id:   "domain1",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+				{
+					Id:   "domain2",
+					Type: aws.AwsApiGatewayV2DomainNameResourceType,
+				},
+				{
+					Id:   "domain3",
+					Type: aws.AwsApiGatewayDomainNameResourceType,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewAwsApiGatewayDomainNamesReconciler()
+			err := m.Execute(&tt.remoteResources, &tt.resourcesFromState)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changelog, err := diff.Diff(tt.expected, tt.remoteResources)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(changelog) > 0 {
+				for _, change := range changelog {
+					t.Errorf("%s got = %v, want %v", strings.Join(change.Path, "."), awsutil.Prettify(change.From), awsutil.Prettify(change.To))
+				}
+			}
+		})
+	}
+}

--- a/pkg/remote/aws/apigatewayv2_domain_name_enumerator.go
+++ b/pkg/remote/aws/apigatewayv2_domain_name_enumerator.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"github.com/snyk/driftctl/pkg/remote/aws/repository"
+	remoteerror "github.com/snyk/driftctl/pkg/remote/error"
+	"github.com/snyk/driftctl/pkg/resource"
+	"github.com/snyk/driftctl/pkg/resource/aws"
+)
+
+type ApiGatewayV2DomainNameEnumerator struct {
+	// AWS SDK list domain names endpoint from API Gateway v2 returns the
+	// same results as the v1 one, thus let's re-use the method from
+	// the API Gateway v1
+	repository repository.ApiGatewayRepository
+	factory    resource.ResourceFactory
+}
+
+func NewApiGatewayV2DomainNameEnumerator(repo repository.ApiGatewayRepository, factory resource.ResourceFactory) *ApiGatewayV2DomainNameEnumerator {
+	return &ApiGatewayV2DomainNameEnumerator{
+		repository: repo,
+		factory:    factory,
+	}
+}
+
+func (e *ApiGatewayV2DomainNameEnumerator) SupportedType() resource.ResourceType {
+	return aws.AwsApiGatewayV2DomainNameResourceType
+}
+
+func (e *ApiGatewayV2DomainNameEnumerator) Enumerate() ([]*resource.Resource, error) {
+	domainNames, err := e.repository.ListAllDomainNames()
+	if err != nil {
+		return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
+	}
+
+	results := make([]*resource.Resource, 0, len(domainNames))
+
+	for _, domainName := range domainNames {
+		results = append(
+			results,
+			e.factory.CreateAbstractResource(
+				string(e.SupportedType()),
+				*domainName.DomainName,
+				map[string]interface{}{},
+			),
+		)
+	}
+
+	return results, err
+}

--- a/pkg/remote/aws/init.go
+++ b/pkg/remote/aws/init.go
@@ -213,6 +213,7 @@ func Init(version string, alerter *alerter.Alerter,
 	remoteLibrary.AddEnumerator(NewApiGatewayV2StageEnumerator(apigatewayv2Repository, factory))
 	remoteLibrary.AddEnumerator(NewApiGatewayV2RouteResponseEnumerator(apigatewayv2Repository, factory))
 	remoteLibrary.AddEnumerator(NewApiGatewayV2MappingEnumerator(apigatewayv2Repository, apigatewayRepository, factory))
+	remoteLibrary.AddEnumerator(NewApiGatewayV2DomainNameEnumerator(apigatewayRepository, factory))
 
 	remoteLibrary.AddEnumerator(NewAppAutoscalingTargetEnumerator(appAutoScalingRepository, factory))
 	remoteLibrary.AddDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, common.NewGenericDetailsFetcher(aws.AwsAppAutoscalingTargetResourceType, provider, deserializer))

--- a/pkg/remote/aws_apigatewayv2_scanner_test.go
+++ b/pkg/remote/aws_apigatewayv2_scanner_test.go
@@ -999,3 +999,82 @@ func TestApiGatewayV2Mapping(t *testing.T) {
 		})
 	}
 }
+
+func TestApiGatewayV2DomainName(t *testing.T) {
+	dummyError := errors.New("this is an error")
+
+	tests := []struct {
+		test           string
+		mocks          func(*repository.MockApiGatewayRepository, *mocks.AlerterInterface)
+		assertExpected func(t *testing.T, got []*resource.Resource)
+		wantErr        error
+	}{
+		{
+			test: "no api gateway v2 domain names",
+			mocks: func(repository *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repository.On("ListAllDomainNames").Return([]*apigateway.DomainName{}, nil)
+			},
+			assertExpected: func(t *testing.T, got []*resource.Resource) {
+				assert.Len(t, got, 0)
+			},
+		},
+		{
+			test: "single api gateway v2 domain name",
+			mocks: func(repository *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repository.On("ListAllDomainNames").Return([]*apigateway.DomainName{
+					{DomainName: awssdk.String("b8r351.example.com")},
+				}, nil)
+			},
+			assertExpected: func(t *testing.T, got []*resource.Resource) {
+				assert.Len(t, got, 1)
+
+				assert.Equal(t, got[0].ResourceId(), "b8r351.example.com")
+				assert.Equal(t, got[0].ResourceType(), resourceaws.AwsApiGatewayV2DomainNameResourceType)
+			},
+		},
+		{
+			test: "cannot list api gateway v2 domain names",
+			mocks: func(repository *repository.MockApiGatewayRepository, alerter *mocks.AlerterInterface) {
+				repository.On("ListAllDomainNames").Return(nil, dummyError)
+				alerter.On("SendAlert", resourceaws.AwsApiGatewayV2DomainNameResourceType, alerts.NewRemoteAccessDeniedAlert(common.RemoteAWSTerraform, remoteerr.NewResourceListingErrorWithType(dummyError, resourceaws.AwsApiGatewayV2DomainNameResourceType, resourceaws.AwsApiGatewayV2DomainNameResourceType), alerts.EnumerationPhase)).Return()
+			},
+			wantErr: remoteerr.NewResourceListingError(dummyError, resourceaws.AwsApiGatewayV2DomainNameResourceType),
+		},
+	}
+
+	providerVersion := "3.19.0"
+	schemaRepository := testresource.InitFakeSchemaRepository("aws", providerVersion)
+	resourceaws.InitResourcesMetadata(schemaRepository)
+	factory := terraform.NewTerraformResourceFactory(schemaRepository)
+
+	for _, c := range tests {
+		t.Run(c.test, func(tt *testing.T) {
+			scanOptions := ScannerOptions{}
+			remoteLibrary := common.NewRemoteLibrary()
+
+			// Initialize mocks
+			alerter := &mocks.AlerterInterface{}
+			fakeRepo := &repository.MockApiGatewayRepository{}
+			c.mocks(fakeRepo, alerter)
+
+			var repo repository.ApiGatewayRepository = fakeRepo
+
+			remoteLibrary.AddEnumerator(aws.NewApiGatewayV2DomainNameEnumerator(repo, factory))
+
+			testFilter := &filter.MockFilter{}
+			testFilter.On("IsTypeIgnored", mock.Anything).Return(false)
+
+			s := NewScanner(remoteLibrary, alerter, scanOptions, testFilter)
+			got, err := s.Resources()
+			assert.Equal(tt, err, c.wantErr)
+			if err != nil {
+				return
+			}
+
+			c.assertExpected(tt, got)
+			alerter.AssertExpectations(tt)
+			fakeRepo.AssertExpectations(tt)
+			testFilter.AssertExpectations(tt)
+		})
+	}
+}

--- a/pkg/resource/aws/aws_apigatewayv2_domain_name.go
+++ b/pkg/resource/aws/aws_apigatewayv2_domain_name.go
@@ -1,0 +1,3 @@
+package aws
+
+const AwsApiGatewayV2DomainNameResourceType = "aws_apigatewayv2_domain_name"

--- a/pkg/resource/aws/aws_apigatewayv2_domain_name_test.go
+++ b/pkg/resource/aws/aws_apigatewayv2_domain_name_test.go
@@ -1,0 +1,52 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/snyk/driftctl/test"
+	"github.com/snyk/driftctl/test/acceptance"
+)
+
+func TestAcc_Aws_ApiGatewayV2DomainName(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		TerraformVersion: "0.15.5",
+		Paths:            []string{"./testdata/acc/aws_apigatewayv2_domain_name"},
+		Args:             []string{"scan"},
+		Checks: []acceptance.AccCheck{
+			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(1)
+				},
+			},
+		},
+	})
+}
+
+func TestAcc_Aws_ApiGatewayV1AndV2DomainNames(t *testing.T) {
+	acceptance.Run(t, acceptance.AccTestCase{
+		TerraformVersion: "0.15.5",
+		Paths:            []string{"./testdata/acc/aws_apigateway_v1v2_domain_names"},
+		Args:             []string{"scan"},
+		Checks: []acceptance.AccCheck{
+			{
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+				},
+				Check: func(result *test.ScanResult, stdout string, err error) {
+					if err != nil {
+						t.Fatal(err)
+					}
+					result.AssertInfrastructureIsInSync()
+					result.AssertManagedCount(2)
+				},
+			},
+		},
+	})
+}

--- a/pkg/resource/aws/metadata_test.go
+++ b/pkg/resource/aws/metadata_test.go
@@ -37,6 +37,7 @@ func TestAWS_Metadata_Flags(t *testing.T) {
 		AwsApiGatewayV2VpcLinkResourceType:            {},
 		AwsApiGatewayV2AuthorizerResourceType:         {},
 		AwsApiGatewayV2RouteResponseResourceType:      {},
+		AwsApiGatewayV2DomainNameResourceType:         {},
 		AwsAppAutoscalingPolicyResourceType:           {resource.FlagDeepMode},
 		AwsAppAutoscalingScheduledActionResourceType:  {},
 		AwsAppAutoscalingTargetResourceType:           {resource.FlagDeepMode},

--- a/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/.driftignore
+++ b/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/.driftignore
@@ -1,0 +1,3 @@
+*
+!aws_api_gateway_domain_name
+!aws_apigatewayv2_domain_name

--- a/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/.terraform.lock.hcl
@@ -1,0 +1,56 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "3.19.0"
+  hashes = [
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.1.0"
+  hashes = [
+    "h1:XTU9f6sGMZHOT8r/+LWCz2BZOPH127FBTPjMMEAAu1U=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_apigateway_v1v2_domain_names/terraform.tf
@@ -1,0 +1,86 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = "3.19.0"
+  }
+}
+
+resource "random_string" "prefix" {
+    length  = 6
+    upper   = false
+    special = false
+}
+
+resource "tls_private_key" "example" {
+    algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example" {
+    allowed_uses = [
+        "key_encipherment",
+        "digital_signature",
+        "server_auth",
+    ]
+
+    key_algorithm         = tls_private_key.example.algorithm
+    private_key_pem       = tls_private_key.example.private_key_pem
+    validity_period_hours = 12
+
+    subject {
+        common_name  = "example-${random_string.prefix.result}.com"
+        organization = "ACME Examples, Inc"
+    }
+}
+
+resource "aws_acm_certificate" "example" {
+    certificate_body = tls_self_signed_cert.example.cert_pem
+    private_key      = tls_private_key.example.private_key_pem
+}
+
+resource "aws_apigatewayv2_domain_name" "example" {
+    domain_name = aws_acm_certificate.example.domain_name
+
+    domain_name_configuration {
+        certificate_arn = aws_acm_certificate.example.arn
+        endpoint_type   = "REGIONAL"
+        security_policy = "TLS_1_2"
+    }
+}
+
+resource "tls_private_key" "example2" {
+    algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example2" {
+    allowed_uses = [
+        "key_encipherment",
+        "digital_signature",
+        "server_auth",
+    ]
+
+    key_algorithm         = tls_private_key.example2.algorithm
+    private_key_pem       = tls_private_key.example2.private_key_pem
+    validity_period_hours = 12
+
+    subject {
+        common_name  = "example2-${random_string.prefix.result}.com"
+        organization = "ACME Examples, Inc"
+    }
+}
+
+resource "aws_acm_certificate" "example2" {
+    certificate_body = tls_self_signed_cert.example2.cert_pem
+    private_key      = tls_private_key.example2.private_key_pem
+}
+
+resource "aws_api_gateway_domain_name" "example2" {
+    domain_name              = aws_acm_certificate.example2.domain_name
+    regional_certificate_arn = aws_acm_certificate.example2.arn
+
+    endpoint_configuration {
+        types = ["REGIONAL"]
+    }
+}

--- a/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/.driftignore
+++ b/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/.driftignore
@@ -1,0 +1,2 @@
+*
+!aws_apigatewayv2_domain_name

--- a/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/.terraform.lock.hcl
+++ b/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/.terraform.lock.hcl
@@ -1,0 +1,56 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.19.0"
+  constraints = "3.19.0"
+  hashes = [
+    "h1:xur9tF49NgsovNnmwmBR8RdpN8Fcg1TD4CKQPJD6n1A=",
+    "zh:185a5259153eb9ee4699d4be43b3d509386b473683392034319beee97d470c3b",
+    "zh:2d9a0a01f93e8d16539d835c02b8b6e1927b7685f4076e96cb07f7dd6944bc6c",
+    "zh:703f6da36b1b5f3497baa38fccaa7765fb8a2b6440344e4c97172516b49437dd",
+    "zh:770855565462abadbbddd98cb357d2f1a8f30f68a358cb37cbd5c072cb15b377",
+    "zh:8008db43149fe4345301f81e15e6d9ddb47aa5e7a31648f9b290af96ad86e92a",
+    "zh:8cdd27d375da6dcb7687f1fed126b7c04efce1671066802ee876dbbc9c66ec79",
+    "zh:be22ae185005690d1a017c1b909e0d80ab567e239b4f06ecacdba85080667c1c",
+    "zh:d2d02e72dbd80f607636cd6237a6c862897caabc635c7b50c0cb243d11246723",
+    "zh:d8f125b66a1eda2555c0f9bbdf12036a5f8d073499a22ca9e4812b68067fea31",
+    "zh:f5a98024c64d5d2973ff15b093725a074c0cb4afde07ef32c542e69f17ac90bc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.1.0"
+  hashes = [
+    "h1:XTU9f6sGMZHOT8r/+LWCz2BZOPH127FBTPjMMEAAu1U=",
+    "zh:3d46616b41fea215566f4a957b6d3a1aa43f1f75c26776d72a98bdba79439db6",
+    "zh:623a203817a6dafa86f1b4141b645159e07ec418c82fe40acd4d2a27543cbaa2",
+    "zh:668217e78b210a6572e7b0ecb4134a6781cc4d738f4f5d09eb756085b082592e",
+    "zh:95354df03710691773c8f50a32e31fca25f124b7f3d6078265fdf3c4e1384dca",
+    "zh:9f97ab190380430d57392303e3f36f4f7835c74ea83276baa98d6b9a997c3698",
+    "zh:a16f0bab665f8d933e95ca055b9c8d5707f1a0dd8c8ecca6c13091f40dc1e99d",
+    "zh:be274d5008c24dc0d6540c19e22dbb31ee6bfdd0b2cddd4d97f3cd8a8d657841",
+    "zh:d5faa9dce0a5fc9d26b2463cea5be35f8586ab75030e7fa4d4920cd73ee26989",
+    "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
+    "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
+    "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
+  ]
+}

--- a/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_apigatewayv2_domain_name/terraform.tf
@@ -1,0 +1,51 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  required_providers {
+    aws = "3.19.0"
+  }
+}
+
+resource "random_string" "prefix" {
+    length  = 6
+    upper   = false
+    special = false
+}
+
+resource "tls_private_key" "example" {
+    algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "example" {
+    allowed_uses = [
+        "key_encipherment",
+        "digital_signature",
+        "server_auth",
+    ]
+
+    key_algorithm         = tls_private_key.example.algorithm
+    private_key_pem       = tls_private_key.example.private_key_pem
+    validity_period_hours = 12
+
+    subject {
+        common_name  = "example-${random_string.prefix.result}.com"
+        organization = "ACME Examples, Inc"
+    }
+}
+
+resource "aws_acm_certificate" "example" {
+    certificate_body = tls_self_signed_cert.example.cert_pem
+    private_key      = tls_private_key.example.private_key_pem
+}
+
+resource "aws_apigatewayv2_domain_name" "example" {
+    domain_name = aws_acm_certificate.example.domain_name
+
+    domain_name_configuration {
+        certificate_arn = aws_acm_certificate.example.arn
+        endpoint_type   = "REGIONAL"
+        security_policy = "TLS_1_2"
+    }
+}

--- a/pkg/resource/resource_types.go
+++ b/pkg/resource/resource_types.go
@@ -151,6 +151,7 @@ var supportedTypes = map[string]ResourceTypeMeta{
 	"aws_apigatewayv2_stage":          {},
 	"aws_apigatewayv2_route_response": {},
 	"aws_apigatewayv2_deployment":     {},
+	"aws_apigatewayv2_domain_name":    {},
 	"aws_launch_template":             {},
 	"aws_launch_configuration":        {},
 	"aws_apigatewayv2_api_mapping":    {},


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1257 
| ❓ Documentation  | https://github.com/snyk/driftctl-docs/pull/211

## Description

Needed to add a new middleware to handle the reconciliation between `aws_api_gateway_domain_name` (v1) and `aws_apigatewayv2_domain_name` (v2) resources.

The all explanation can be easily sum up by a small example:

```hcl
resource "aws_api_gateway_domain_name" "foo" {
  domain_name              = "foo.example.com"
  regional_certificate_arn = aws_acm_certificate.foo.arn

  endpoint_configuration {
    types = ["REGIONAL"]
  }
}

resource "aws_apigatewayv2_domain_name" "bar" {
  domain_name = "bar.example.com"

  domain_name_configuration {
    certificate_arn = aws_acm_certificate.bar.arn
    endpoint_type   = "REGIONAL"
  }
}
```

If you try to apply these 2 resources and use the AWS SDK to list all domain names with the v1 and v2 endpoints you will get both resources as result of each endpoint as per below images.

![image](https://user-images.githubusercontent.com/8110579/149368777-40a6bb9e-c09f-43ee-9b9e-c4ecab810230.png)
![image](https://user-images.githubusercontent.com/8110579/149368800-c3943556-3a90-4059-bb02-a118a7c6d2dc.png)

Unfortunately there are no ways to distinct a v1 from a v2 by looking at the structs... So we decided to go the middleware way with one that will find matching domain names between a remote and a state resource and only leave v1 format as unmanaged domain names.