### PR TITLE
chore: change namings in the apigtw api middleware

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -112,7 +112,7 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 		middlewares.NewRDSClusterInstanceExpander(d.resourceFactory),
 		middlewares.NewAwsApiGatewayDeploymentExpander(d.resourceFactory),
 		middlewares.NewAwsApiGatewayResourceExpander(d.resourceFactory),
-		middlewares.NewAwsApiGatewayRestApiExpander(d.resourceFactory),
+		middlewares.NewAwsApiGatewayApiExpander(d.resourceFactory),
 		middlewares.NewAwsApiGatewayRestApiPolicyExpander(d.resourceFactory),
 		middlewares.NewAwsConsoleApiGatewayGatewayResponse(),
 

--- a/pkg/middlewares/aws_api_gateway_api_expander_test.go
+++ b/pkg/middlewares/aws_api_gateway_api_expander_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/snyk/driftctl/pkg/terraform"
 )
 
-func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
+func TestAwsApiGatewayApiExpander_Execute(t *testing.T) {
 	tests := []struct {
 		name               string
 		resourcesFromState []*resource.Resource
@@ -1095,7 +1095,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "creates routes from OpenAPI v3 YAML document",
+			name: "creates routes from OpenAPI v3 YAML document (apigatewayv2)",
 			resourcesFromState: []*resource.Resource{
 				{
 					Id:   "a-gateway",
@@ -1179,7 +1179,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "creates routes from OpenAPI v2 JSON document",
+			name: "creates routes from OpenAPI v2 JSON document (apigatewayv2)",
 			resourcesFromState: []*resource.Resource{
 				{
 					Id:   "a-gateway",
@@ -1221,7 +1221,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "creates routes and integration from OpenAPI v2 JSON document",
+			name: "creates routes and integration from OpenAPI v2 JSON document (apigatewayv2)",
 			resourcesFromState: []*resource.Resource{
 				{
 					Id:   "a-gateway",
@@ -1281,7 +1281,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: "creates routes and integrations from OpenAPI v3 YAML document",
+			name: "creates routes and integrations from OpenAPI v3 YAML document (apigatewayv2)",
 			resourcesFromState: []*resource.Resource{
 				{
 					Id:   "a-gateway",
@@ -1348,7 +1348,7 @@ func TestAwsApiGatewayRestApiExpander_Execute(t *testing.T) {
 				tt.mocks(factory)
 			}
 
-			m := NewAwsApiGatewayRestApiExpander(factory)
+			m := NewAwsApiGatewayApiExpander(factory)
 			err := m.Execute(&tt.remoteResources, &tt.resourcesFromState)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

This middleware is no more only about rest API (v1) and should take into account v2 as well. I also add `(apigatewayv2)` at the end of v2 tests of this middleware to avoid confusion.