### PR TITLE
Add sleep-backoff to GCP ACC tests [CFG-1305]

### DIFF
--- a/pkg/resource/google/google_bigquery_dataset_test.go
+++ b/pkg/resource/google/google_bigquery_dataset_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_BigqueryDataset(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply operation
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/pkg/resource/google/google_bigquery_table_test.go
+++ b/pkg/resource/google/google_bigquery_table_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_BigqueryTable(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply operation
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/pkg/resource/google/google_bigtable_instance_test.go
+++ b/pkg/resource/google/google_bigtable_instance_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_BigtableInstance(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/pkg/resource/google/google_cloudfunctions_function_test.go
+++ b/pkg/resource/google/google_cloudfunctions_function_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_CloudFunctionsFunction(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/pkg/resource/google/google_sql_database_instance_test.go
+++ b/pkg/resource/google/google_sql_database_instance_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_SQLDatabaseInstance(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 300 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < 5*time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {

--- a/pkg/resource/google/google_storage_bucket_test.go
+++ b/pkg/resource/google/google_storage_bucket_test.go
@@ -18,10 +18,15 @@ func TestAcc_Google_StorageBucket(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
-				// New resources are not visible immediately on GCP api after an apply
-				// Logic below retry driftctl scan until we can retrieve the results (infra will be in sync) and for maximum 60 seconds
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					return !result.IsSync() && retryDuration < time.Minute
+					if result.IsSync() || retryDuration > 10*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
 				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {


### PR DESCRIPTION
## Description

As per a discussion with @craigfurman on [CFG-1305](https://snyksec.atlassian.net/browse/CFG-1305), we agreed that retrying the scan in a tight loop was not ideal and we should use some linear or exponential sleep-backoff instead. The common problem that seem to affect all GCP acc tests is that the asset API sometimes return cached result, making new resource appear as missing ([example](https://app.circleci.com/pipelines/github/snyk/driftctl/4118/workflows/5ab1d12f-eb0b-40c2-bdf1-cad9a47dd1b6/jobs/8763)). The [GCP docs](https://cloud.google.com/asset-inventory/docs/faq#result-stale) says : 

> Data freshness in the Cloud Asset API is on a best-effort basis. While almost all asset updates will be available to clients in minutes, in rare cases it's possible the result of the Cloud Asset API methods won't include the most recent asset updates.

What we were doing before basically is 
- `retry the scan if it didn't succeed and we've been scanning for less than a minute`.

What this change suggests is 
- `retry the scan if it didn't succeed, after 3 minutes, once`.

Retrying in a loop for a minute appear to be less efficient than retrying once after some time. I think 3 minutes is a reasonable time frame for an nightly run.