### PR TITLE
Add issue-tagging script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,20 @@ jobs:
             command: |
               curl -X POST https://api.github.com/repos/snyk/driftctl-docs/dispatches \
                 -d '{"event_type": "new_version"}' \
-                -H "Authorization: token ${GITHUB_TOKEN}"
+                -H "Authorization: token $GITHUB_TOKEN"
+  issue-tagging:
+      machine:
+          image: ubuntu-2004:202010-01
+      steps:
+          - checkout
+          - gh/setup:
+                version: 2.2.0
+          - attach_workspace:
+                at: ~/project
+          - run:
+                name: Auto label issues with the newly released version
+                command: |
+                    ./scripts/issue-tagging.sh
   update-lambda:
     environment:
         FUNCTION_NAME: driftctl-version
@@ -319,3 +332,13 @@ workflows:
                 only: /^v.*/
               branches:
                 ignore: /.*/
+      - issue-tagging:
+            context:
+                - driftctl
+            requires:
+                - release
+            filters:
+                tags:
+                    only: /^v.*/
+                branches:
+                    ignore: /.*/

--- a/scripts/issue-tagging.sh
+++ b/scripts/issue-tagging.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# This script compares merged pull requests between the two most recent tags
+# Please note that this script only works with Github repositories.
+# Prerequisites: git, github cli, curl
+
+set -euo pipefail
+
+GHCLI_BIN="gh"
+REPO="snyk/driftctl"
+LATEST_TAG=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 1p) # Get the latest created tag
+BASE_TAG=$(git for-each-ref --sort=-taggerdate --format '%(tag)' refs/tags | sed -n 2p) # Get the second latest created tag
+
+# Check GH CLI is installed
+if ! which $GHCLI_BIN &> /dev/null; then
+    echo "GitHub CLI ($GHCLI_BIN) is not installed, visit https://github.com/cli/cli#installation"
+    exit 1
+fi
+
+# Check GH authentication
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+    echo "GITHUB_TOKEN environment variable is not set, it is required to use the GitHub API."
+    exit 1
+fi
+
+# Check GH authentication
+if ! $GHCLI_BIN auth status &> /dev/null; then
+    echo "You are not logged into any GitHub hosts. Run gh auth login to authenticate."
+    exit 1
+fi
+
+# Compare $BASE_TAG branch with the latest tag
+# Keep IDs of merged pull requests
+PRs=$(git log --pretty=oneline "$BASE_TAG"..."$LATEST_TAG" | grep 'Merge pull request #' | grep -oE '#[0-9]+' | sed 's/#//')
+
+# Find fixed issues from $BASE_TAG to $LATEST_TAG
+ISSUES=()
+for pr in $PRs; do
+    id=$($GHCLI_BIN pr view "$pr" --json body | grep -oE 'Related issues | #[0-9]+' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g')
+    ISSUES+=("$id")
+done
+
+echo "Creating milestone $BASE_TAG in github.com/$REPO"
+curl -X POST \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    --data "{\"title\":\"$BASE_TAG\"}" \
+    "https://api.github.com/repos/$REPO/milestone"
+
+for issue in "${ISSUES[@]}"; do
+    if [ -z "$issue" ]; then
+        continue
+    fi
+    echo "Adding milestone $BASE_TAG to issue #$issue"
+    gh issue edit "$issue" -m "$BASE_TAG"
+
+    curl -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        --data "{\"body\":\"This issue has been referenced in the latest release $BASE_TAG.\"}" \
+        "https://api.github.com/repos/$REPO/issues/$issue/comments"
+done
+
+echo "Done."


### PR DESCRIPTION
## Description

As discussed in [CFG-1344](https://snyksec.atlassian.net/browse/CFG-1344) : 

> We want to have a mechanism to flag issues (by adding a comment, a label, milestone, whatever) to the version there were released. 

This PR creates a `issue-tagging` script that automatically flag fixed issues with a milestone when we release a new version of driftctl. For example, let's say we release v1.0.2 that fixes issue #A and #B, running this script will create a milestone `v1.0.2` (if it doesn't exist already) and add it to issue #A and #B. It will also add a comment to notify the OP that a new version is available.

I've searched for existing bots or software that would do what we want but found nothing that really fits with our needs. If you think this script is too much to deal with, let me know.

### References

- https://docs.github.com/en/rest/reference/issues#create-a-milestone
- https://cli.github.com/manual/gh_issue_edit