### PR TITLE
fix: assign a specific az while creating subnets

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_apigatewayv2_vpc_link/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_apigatewayv2_vpc_link/terraform.tf
@@ -15,6 +15,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_subnet" "subnet" {
     vpc_id = aws_vpc.vpc.id
     cidr_block = "10.100.0.0/24"
+    availability_zone_id = "use1-az1"
 }
 
 resource "aws_security_group" "foo" {


### PR DESCRIPTION
Sometimes we got this error in our acc test:

```
Error: error creating API Gateway v2 VPC Link: BadRequestException: Subnet 'subnet-0fc248a9afd376dba' is in Availability Zone 'use1-az3' where service is not available
        
          with aws_apigatewayv2_vpc_link.foo,
          on terraform.tf line 24, in resource "aws_apigatewayv2_vpc_link" "foo":
          24: resource "aws_apigatewayv2_vpc_link" "foo" {
        
        : exit status 1
```

This PR will fix this issue by assigning a specific availability zone each time we create subnets.