### PR TITLE
Ignore default aws_api_gateway_account resources

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -129,6 +129,7 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 			middlewares.NewAwsDefaults(),
 			middlewares.NewGoogleLegacyBucketIAMMember(),
 			middlewares.NewGoogleDefaultIAMMember(),
+			middlewares.NewAwsDefaultApiGatewayAccount(),
 		)
 	}
 

--- a/pkg/middlewares/aws_default_api_gateway_account.go
+++ b/pkg/middlewares/aws_default_api_gateway_account.go
@@ -1,0 +1,52 @@
+package middlewares
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/snyk/driftctl/pkg/resource"
+	"github.com/snyk/driftctl/pkg/resource/aws"
+)
+
+// AwsDefaultApiGatewayAccount is a middleware that ignores default API gateway account resources in the current region
+type AwsDefaultApiGatewayAccount struct{}
+
+func NewAwsDefaultApiGatewayAccount() AwsDefaultApiGatewayAccount {
+	return AwsDefaultApiGatewayAccount{}
+}
+
+func (m AwsDefaultApiGatewayAccount) Execute(remoteResources, resourcesFromState *[]*resource.Resource) error {
+
+	newRemoteResources := make([]*resource.Resource, 0)
+
+	for _, remoteResource := range *remoteResources {
+		// Ignore all resources other than API gateway account
+		if remoteResource.ResourceType() != aws.AwsApiGatewayAccountResourceType {
+			newRemoteResources = append(newRemoteResources, remoteResource)
+			continue
+		}
+
+		// Check if account is managed by IaC
+		existInState := false
+		for _, stateResource := range *resourcesFromState {
+			if remoteResource.Equal(stateResource) {
+				existInState = true
+				break
+			}
+		}
+
+		// Include resource if it's managed in IaC
+		if existInState {
+			newRemoteResources = append(newRemoteResources, remoteResource)
+			continue
+		}
+
+		// Else, resource is not added to newRemoteResources slice, so it will be ignored
+		logrus.WithFields(logrus.Fields{
+			"id":   remoteResource.ResourceId(),
+			"type": remoteResource.ResourceType(),
+		}).Debug("Ignoring default API gateway account as it is not managed by IaC")
+	}
+
+	*remoteResources = newRemoteResources
+
+	return nil
+}

--- a/pkg/middlewares/aws_default_api_gateway_account.go
+++ b/pkg/middlewares/aws_default_api_gateway_account.go
@@ -6,7 +6,7 @@ import (
 	"github.com/snyk/driftctl/pkg/resource/aws"
 )
 
-// AwsDefaultApiGatewayAccount is a middleware that ignores default API gateway account resources in the current region
+// AwsDefaultApiGatewayAccount is a middleware that ignores the default API Gateway account resource in the current region.
 type AwsDefaultApiGatewayAccount struct{}
 
 func NewAwsDefaultApiGatewayAccount() AwsDefaultApiGatewayAccount {

--- a/pkg/middlewares/aws_default_api_gateway_account_test.go
+++ b/pkg/middlewares/aws_default_api_gateway_account_test.go
@@ -19,7 +19,7 @@ func TestAwsDefaultApiGatewayAccount_Execute(t *testing.T) {
 		expected           []*resource.Resource
 	}{
 		{
-			"test that default account are not ignored when managed by IaC",
+			"test that default account is not ignored when managed by IaC",
 			[]*resource.Resource{
 				{
 					Id: "fake",
@@ -54,7 +54,7 @@ func TestAwsDefaultApiGatewayAccount_Execute(t *testing.T) {
 			},
 		},
 		{
-			"test that default account are ignored when not managed by IaC",
+			"test that default account is ignored when not managed by IaC",
 			[]*resource.Resource{
 				{
 					Id: "fake",


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1217
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

> We all have an aws_api_gateway_account resource inside each region of AWS that will by default output as unmanaged. We should ignore this one unless you manage it by Terraform.

This PR adds a simple middleware to ignore remote `aws_api_gateway_account` resources when it's not managed by Terraform.

**Notes to reviewers**:
- I didn't find a way to differentiate default and managed resources, so beware of the impact of this change
- This middleware will not run in strict mode