### PR TITLE
Fix string concatenation in curl command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ jobs:
             command: |
               curl -X POST https://api.github.com/repos/snyk/driftctl-docs/dispatches \
                 -d '{"event_type": "new_version"}' \
-                -H 'Authorization: token $GITHUB_TOKEN'
+                -H "Authorization: token ${GITHUB_TOKEN}"
   update-lambda:
     environment:
         FUNCTION_NAME: driftctl-version


### PR DESCRIPTION
## Description

This PR fixes a bad string concatenation in the curl command we use to trigger a workflow run in the docs repository. Currently, the header doesn't use the `GITHUB_TOKEN` variable well, resulting in [a "bad credentials" response](https://app.circleci.com/pipelines/github/snyk/driftctl/4150/workflows/6deb3dbd-e68c-4302-af31-872b3e014700/jobs/8888).