### PR TITLE
Capitalize terraform in output

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func run() int {
 	if checkVersion {
 		newVersion := <-latestVersionChan
 		if newVersion != "" {
-			_, _ = fmt.Fprintln(os.Stderr, "\n\nYour version of driftctl is outdated, please upgrade !")
+			_, _ = fmt.Fprintln(os.Stderr, "\n\nYour version of driftctl is outdated, please upgrade!")
 			_, _ = fmt.Fprintf(os.Stderr, "Current: %s; Latest: %s\n", version.Current(), newVersion)
 		}
 	}

--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -201,7 +201,7 @@ func (c Console) writeSummary(analysis *analyser.Analysis) {
 		if analysis.Summary().TotalManaged > 0 {
 			managed = warningWriter.Sprintf("%d", analysis.Summary().TotalManaged)
 		}
-		fmt.Printf(" - %s resource(s) managed by terraform\n", managed)
+		fmt.Printf(" - %s resource(s) managed by Terraform\n", managed)
 
 		drifted := successWriter.Sprintf("0")
 		if analysis.Summary().TotalDrifted > 0 {

--- a/pkg/cmd/scan/output/testdata/output.txt
+++ b/pkg/cmd/scan/output/testdata/output.txt
@@ -23,7 +23,7 @@ Found changed resources:
         - a: "oldValue" => <nil>
 Found 10 resource(s)
  - 20% coverage
- - 2 resource(s) managed by terraform
+ - 2 resource(s) managed by Terraform
      - 2/2 resource(s) out of sync with Terraform state
  - 4 resource(s) not managed by Terraform
  - 4 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.txt
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.txt
@@ -8,7 +8,7 @@ Found changed resources:
         ~ struct.0.string: "one" => "two" (computed)
 Found 1 resource(s)
  - 100% coverage
- - 1 resource(s) managed by terraform
+ - 1 resource(s) managed by Terraform
      - 1/1 resource(s) out of sync with Terraform state
  - 0 resource(s) not managed by Terraform
  - 0 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_empty_attributes.txt
+++ b/pkg/cmd/scan/output/testdata/output_empty_attributes.txt
@@ -6,7 +6,7 @@ Found resources not covered by IaC:
     - duysgkfdjfdgfhd
 Found 3 resource(s)
  - 33% coverage
- - 1 resource(s) managed by terraform
+ - 1 resource(s) managed by Terraform
      - 0/1 resource(s) out of sync with Terraform state
  - 1 resource(s) not managed by Terraform
  - 1 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_json_fields.txt
+++ b/pkg/cmd/scan/output/testdata/output_json_fields.txt
@@ -30,7 +30,7 @@ Found changed resources:
 
 Found 2 resource(s)
  - 100% coverage
- - 2 resource(s) managed by terraform
+ - 2 resource(s) managed by Terraform
      - 2/2 resource(s) out of sync with Terraform state
  - 0 resource(s) not managed by Terraform
  - 0 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_stringer_resources.txt
+++ b/pkg/cmd/scan/output/testdata/output_stringer_resources.txt
@@ -13,7 +13,7 @@ Found changed resources:
             ~ Name: "" => "resource with diff"
 Found 3 resource(s)
  - 33% coverage
- - 1 resource(s) managed by terraform
+ - 1 resource(s) managed by Terraform
      - 1/1 resource(s) out of sync with Terraform state
  - 1 resource(s) not managed by Terraform
  - 1 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_without_deep.txt
+++ b/pkg/cmd/scan/output/testdata/output_without_deep.txt
@@ -3,6 +3,6 @@ Found resources not covered by IaC:
     - unmanaged-id-1
 Found 1 resource(s)
  - 0% coverage
- - 0 resource(s) managed by terraform
+ - 0 resource(s) managed by Terraform
  - 1 resource(s) not managed by Terraform
  - 0 resource(s) found in a Terraform state but missing on the cloud provider


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | None
| ❓ Documentation  | no

## Description

A quick 💅 
- removing redundant space before exclamation mark in output
- capitalizing `Terraform` in output for consistency and correctness, currently we have once no-capitalized and twice capitalized.
![image](https://user-images.githubusercontent.com/42895464/151695045-f705e5a7-fef0-49cb-bff1-17f29e7f93ce.png)
