### PR TITLE
Update retry policy for GCP acc tests

### DIFF
--- a/pkg/resource/google/google_bigquery_table_test.go
+++ b/pkg/resource/google/google_bigquery_table_test.go
@@ -22,7 +22,7 @@ func TestAcc_Google_BigqueryTable(t *testing.T) {
 				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
 				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
+					if result.IsSync() || retryDuration > 15*time.Minute {
 						return false
 					}
 					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)

--- a/pkg/resource/google/google_compute_global_address_test.go
+++ b/pkg/resource/google/google_compute_global_address_test.go
@@ -22,7 +22,7 @@ func TestAcc_Google_ComputeGlobalAddress(t *testing.T) {
 				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
 				// and doubling the amount of time waited after each one.
 				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
+					if result.IsSync() || retryDuration > 15*time.Minute {
 						return false
 					}
 					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)

--- a/test/acceptance/testing.go
+++ b/test/acceptance/testing.go
@@ -438,7 +438,10 @@ func Run(t *testing.T, c AccTestCase) {
 			if check.ShouldRetry == nil || !check.ShouldRetry(result, time.Since(timeBeforeRetry), retryCount) {
 				break
 			}
-			logrus.WithField("count", fmt.Sprintf("%d", retryCount)).Debug("Retrying scan ...")
+			logrus.
+				WithField("count", fmt.Sprintf("%d", retryCount)).
+				WithField("retry_duration", time.Since(timeBeforeRetry).Round(time.Second)).
+				Debug("Retrying scan ...")
 			_, _, _ = runDriftCtlCmd(driftctlCmd)
 			result = c.getResult(t)
 			retryCount++


### PR DESCRIPTION
## Description

Those particular tests seems to have more regression than others. This PR increases the retry duration from 10 to 15 minutes so it will retry one more time after sleeping for 8 min.

```
Retry count 	0  1  2  3   4 
Sleep 	 	0  2  4  6   8
Retry duration	0  2  6  12  20  # Stopping here since 20>15
```

Also added a field `retry_duration` to debug logs so we can figure out the elapsed time for this test to pass/fail in the future.

### References

- https://app.circleci.com/pipelines/github/snyk/driftctl/4187/workflows/0e27db19-91a1-4355-b081-a130a3e6d741/jobs/9040
- https://app.circleci.com/pipelines/github/snyk/driftctl/4182/workflows/716a9d08-c662-47c9-b9f1-d52d756290de/jobs/9020
- https://app.circleci.com/pipelines/github/snyk/driftctl/4167/workflows/0b6e137c-e0c5-482b-a614-11a7bdf8dd40/jobs/8962