### PR TITLE
Add a service flag to scan a group of resources

### DIFF
--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -33,6 +33,7 @@ type ScanOptions struct {
 	ProviderVersion  string
 	ConfigDir        string
 	DriftignorePath  string
+	Driftignores     []string
 	Deep             bool
 }
 


### PR DESCRIPTION
Q | A
-- | --
🐛 Bug fix? | no
🚀 New feature? | yes
⚠ Deprecations? | no
❌ BC Break | no
🔗 Related issues | 
❓ Documentation | TODO


## Description

This feature is for adding a new flag called `service` to scan command so that a user scan a set of resources that represents a service. 

For example specifying --service="s3" would automatically expand the scan to the following resources:

- aws_s3_bucket
- aws_s3_bucket_analytics_configuration
- aws_s3_bucket_inventory	
- aws_s3_bucket_metric
- aws_s3_bucket_notification
- aws_s3_bucket_policy

### Service<> Resource Mapping

The initial thought of using a single prefix for services would not cover all of the use cases. Here are some examples where there is not a common prefix which represents a service  from a TF provider perspective: AWS EC2 resources, [this](https://registry.terraform.io/providers/hashicorp/google/latest/docs#:~:text=Workflows-,Resources,-google_assured_workloads_workload) , [this](https://registry.terraform.io/providers/hashicorp/google/latest/docs#:~:text=Access-,Approval,-Resources) or [this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#:~:text=App-,Service,-(Web%20Apps)). 

Initially we could use a self managed list to assign resources to 1 or more services.

[resource_types.go](https://github.com/snyk/driftctl/commit/158278752b13a20af31bb9e26591d2df7c23eb61#diff-5b68fbcba7c1ba6f4064ea7a27e7265704535d091d82e458799114b16ac011ec) is used for mapping services to resources.  Atm only two services are added, if we agree on the method I will be adding more services.

### Ignores
In order to avoid conflicts between ignore files and individual ignore patterns, whenever ignore patterns are present ignorefiles will not be processed.

### Tests
I have not added any tests, I'm just looking for feedback on the general approach. Once we agree on the approach, will be adding all the tests.



