### PR TITLE
Add retry policy for remaining GCP acc tests

### DIFF
--- a/pkg/resource/google/google_bigquery_dataset_test.go
+++ b/pkg/resource/google/google_bigquery_dataset_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_BigqueryDataset(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_bigquery_table_test.go
+++ b/pkg/resource/google/google_bigquery_table_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_BigqueryTable(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 15*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(15 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_bigtable_instance_test.go
+++ b/pkg/resource/google/google_bigtable_instance_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_BigtableInstance(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_bigtable_table_test.go
+++ b/pkg/resource/google/google_bigtable_table_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_BigtableTable(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_cloudfunctions_function_test.go
+++ b/pkg/resource/google/google_cloudfunctions_function_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_CloudFunctionsFunction(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_compute_global_address_test.go
+++ b/pkg/resource/google/google_compute_global_address_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_ComputeGlobalAddress(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 15*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_compute_instance_test.go
+++ b/pkg/resource/google/google_compute_instance_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -17,6 +18,16 @@ func TestAcc_Google_ComputeInstance(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
+				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
+					if result.IsSync() || retryDuration > 15*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
+				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_compute_instance_test.go
+++ b/pkg/resource/google/google_compute_instance_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_ComputeInstance(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 15*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(15 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_compute_network_test.go
+++ b/pkg/resource/google/google_compute_network_test.go
@@ -2,6 +2,7 @@ package google_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -18,6 +19,16 @@ func TestAcc_Google_ComputeNetwork(t *testing.T) {
 		},
 		Checks: []acceptance.AccCheck{
 			{
+				// New resources are not visible immediately through GCP API after an apply operation.
+				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
+				// and doubling the amount of time waited after each one.
+				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
+					if result.IsSync() || retryDuration > 15*time.Minute {
+						return false
+					}
+					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
+					return true
+				},
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_compute_network_test.go
+++ b/pkg/resource/google/google_compute_network_test.go
@@ -20,15 +20,7 @@ func TestAcc_Google_ComputeNetwork(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 15*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(15 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_sql_database_instance_test.go
+++ b/pkg/resource/google/google_sql_database_instance_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_SQLDatabaseInstance(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)

--- a/pkg/resource/google/google_storage_bucket_test.go
+++ b/pkg/resource/google/google_storage_bucket_test.go
@@ -19,15 +19,7 @@ func TestAcc_Google_StorageBucket(t *testing.T) {
 		Checks: []acceptance.AccCheck{
 			{
 				// New resources are not visible immediately through GCP API after an apply operation.
-				// Logic below retries driftctl scan using a back-off strategy of retrying 'n' times
-				// and doubling the amount of time waited after each one.
-				ShouldRetry: func(result *test.ScanResult, retryDuration time.Duration, retryCount uint8) bool {
-					if result.IsSync() || retryDuration > 10*time.Minute {
-						return false
-					}
-					time.Sleep((2 * time.Duration(retryCount)) * time.Minute)
-					return true
-				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
## Description

This PR adds a retry policy for some GCP tests that failed recently without retrying. It also creates a new common `LinearBackoff` function so we don't duplicate the retry policy for each test.

Tests where I added the retry policy : 
- `TestAcc_Google_ComputeInstance`
- `TestAcc_Google_ComputeNetwork`

**References**

- https://app.circleci.com/pipelines/github/snyk/driftctl/4195/workflows/5e665d3d-db9e-485b-bc29-1b106fd9846a/jobs/9071