### PR TITLE
Disambiguate between drift and error exit codes

### DIFF
--- a/pkg/cmd/scan/exit_codes.go
+++ b/pkg/cmd/scan/exit_codes.go
@@ -1,0 +1,7 @@
+package scan
+
+const (
+	EXIT_IN_SYNC     = 0
+	EXIT_NOT_IN_SYNC = 1
+	EXIT_ERROR       = 2
+)

--- a/pkg/remote/terraform/provider.go
+++ b/pkg/remote/terraform/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/snyk/driftctl/pkg/cmd/scan"
 	"github.com/snyk/driftctl/pkg/output"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -63,7 +64,7 @@ func (p *TerraformProvider) Init() error {
 		case <-c:
 			logrus.Warn("Detected interrupt during terraform provider configuration, cleanup ...")
 			p.Cleanup()
-			os.Exit(1)
+			os.Exit(scan.EXIT_ERROR)
 		case <-stopCh:
 			return
 		}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | **yes**
| 🔗 Related issues | https://github.com/snyk/driftctl/issues/1350
| ❓ Documentation  | yes

## Description

`driftctl scan` exits with zero only when there is no detected drift.
Prior to this commit, it exited with 1 when there was a non-panic error,
and also when there was detected drift. This makes error handling in
scripts more awkward than it needs to be.

This commit changes the exit code to 2 whenever there are errors during
a scan, whether that error is from a panic or not, leaving 1 as the exit
code used solely for when drift is detected.

Related: https://github.com/snyk/driftctl/issues/1350

---

I grepped the codebase for `os.Exit`, I think I covered all instances.

At a glance, I don't think cobra supports length paragraphs for `--help` docs, although we might be able to (ab)use Usage for that. Perhaps it's best to instead accompany this PR with a section on the docs website about exit codes?