### PR TITLE
adding `humanReadableAttributes` to JSON output

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -99,9 +99,10 @@ type ResourceFactory interface {
 }
 
 type SerializableResource struct {
-	Id     string              `json:"id"`
-	Type   string              `json:"type"`
-	Source *SerializableSource `json:"source,omitempty"`
+	Id                 string              `json:"id"`
+	Type               string              `json:"type"`
+	ReadableAttributes map[string]string   `json:"human_readable_attributes,omitempty"`
+	Source             *SerializableSource `json:"source,omitempty"`
 }
 
 func NewSerializableResource(res *Resource) *SerializableResource {
@@ -114,10 +115,18 @@ func NewSerializableResource(res *Resource) *SerializableResource {
 		}
 	}
 	return &SerializableResource{
-		Id:     res.ResourceId(),
-		Type:   res.ResourceType(),
-		Source: src,
+		Id:                 res.ResourceId(),
+		Type:               res.ResourceType(),
+		ReadableAttributes: formatReadableAttributes(res),
+		Source:             src,
 	}
+}
+
+func formatReadableAttributes(res *Resource) map[string]string {
+	if res.Schema() == nil || res.Schema().HumanReadableAttributesFunc == nil {
+		return map[string]string{}
+	}
+	return res.Schema().HumanReadableAttributesFunc(res)
 }
 
 type NormalizedResource interface {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1325
| ❓ Documentation  | no

## Description

added `human_readable_attributes` field to json output e.q.
```json
{
    "id": "sgrule-1180062852",
    "type": "aws_security_group_rule",
    "human_readable_attributes": {
        "Destination": "0.0.0.0/0",
        "Ports": "All",
        "Protocol": "All",
        "SecurityGroup": "sg-08e4f811ab524c960",
        "Type": "egress"
    }
}
```

```json
{
    "id": "nacl-4081969105",
    "type": "aws_network_acl_rule",
    "human_readable_attributes": {
        "CIDR": "0.0.0.0/0",
        "Egress": "true",
        "Network": "acl-4f2eda2b",
        "Protocol": "All",
        "Rule number": "100"
    }
}
```