### PR TITLE
New --only-managed / --only-unmanaged flags

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -204,6 +204,10 @@ func (a *Analysis) SetAlerts(alerts alerter.Alerts) {
 	a.alerts = alerts
 }
 
+func (a *Analysis) SetOptions(options AnalyzerOptions) {
+	a.options = options
+}
+
 func (a *Analysis) Coverage() int {
 	if a.summary.TotalResources > 0 {
 		return int((float32(a.summary.TotalManaged) / float32(a.summary.TotalResources)) * 100.0)

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -38,7 +38,9 @@ func (c *ComputedDiffAlert) ShouldIgnoreResource() bool {
 }
 
 type AnalyzerOptions struct {
-	Deep bool
+	Deep          bool
+	OnlyManaged   bool
+	OnlyUnmanaged bool
 }
 
 type Analyzer struct {
@@ -72,7 +74,9 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []*resource.Resour
 		}
 
 		if !found {
-			analysis.AddDeleted(stateRes)
+			if !analysis.Options().OnlyUnmanaged {
+				analysis.AddDeleted(stateRes)
+			}
 			continue
 		}
 
@@ -80,8 +84,8 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []*resource.Resour
 		filteredRemoteResource = removeResourceByIndex(i, filteredRemoteResource)
 		analysis.AddManaged(stateRes)
 
-		// Stop there if we are not in deep mode, we do not want to compute diffs
-		if !a.options.Deep {
+		// Stop there if we are not in deep mode or in only-managed mode, we do not want to compute diffs
+		if !a.options.Deep && !a.options.OnlyManaged {
 			continue
 		}
 
@@ -130,7 +134,9 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []*resource.Resour
 	}
 
 	// Add remaining unmanaged resources
-	analysis.AddUnmanaged(filteredRemoteResource...)
+	if !analysis.Options().OnlyManaged {
+		analysis.AddUnmanaged(filteredRemoteResource...)
+	}
 
 	// Sort resources by Terraform Id
 	// The purpose is to have a predictable output

--- a/pkg/analyser/analyzer.go
+++ b/pkg/analyser/analyzer.go
@@ -84,8 +84,8 @@ func (a Analyzer) Analyze(remoteResources, resourcesFromState []*resource.Resour
 		filteredRemoteResource = removeResourceByIndex(i, filteredRemoteResource)
 		analysis.AddManaged(stateRes)
 
-		// Stop there if we are not in deep mode or in only-managed mode, we do not want to compute diffs
-		if !a.options.Deep && !a.options.OnlyManaged {
+		// Stop there if we are not in deep mode, we do not want to compute diffs
+		if !a.options.Deep {
 			continue
 		}
 

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -1068,6 +1068,7 @@ func TestAnalyze(t *testing.T) {
 			},
 			options: &AnalyzerOptions{
 				OnlyManaged: true,
+				Deep:        true,
 			},
 		},
 		{

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -228,6 +228,16 @@ func NewScanCmd(opts *pkg.ScanOptions) *cobra.Command {
 		configDir,
 		"Directory path that driftctl uses for configuration.\n",
 	)
+	fl.BoolVar(&opts.OnlyManaged,
+		"only-managed",
+		false,
+		"Report only what's managed by your IaC\n",
+	)
+	fl.BoolVar(&opts.OnlyUnmanaged,
+		"only-unmanaged",
+		false,
+		"Report only what's not managed by your IaC\n",
+	)
 
 	return cmd
 }
@@ -271,7 +281,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	logrus.Debug("Checking for driftignore")
 	driftIgnore := filter.NewDriftIgnore(opts.DriftignorePath, opts.Driftignores...)
 
-	scanner := remote.NewScanner(remoteLibrary, alerter, remote.ScannerOptions{Deep: opts.Deep}, driftIgnore)
+	scanner := remote.NewScanner(remoteLibrary, alerter, remote.ScannerOptions{Deep: opts.Deep, OnlyManaged: opts.OnlyManaged}, driftIgnore)
 
 	iacSupplier, err := supplier.GetIACSupplier(opts.From, providerLibrary, opts.BackendOptions, iacProgress, alerter, resFactory, driftIgnore)
 	if err != nil {
@@ -282,7 +292,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 		scanner,
 		iacSupplier,
 		alerter,
-		analyser.NewAnalyzer(alerter, analyser.AnalyzerOptions{Deep: opts.Deep}, driftIgnore),
+		analyser.NewAnalyzer(alerter, analyser.AnalyzerOptions{Deep: opts.Deep, OnlyManaged: opts.OnlyManaged, OnlyUnmanaged: opts.OnlyUnmanaged}, driftIgnore),
 		resFactory,
 		opts,
 		scanProgress,

--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -109,6 +109,10 @@ func NewScanCmd(opts *pkg.ScanOptions) *cobra.Command {
 
 			opts.ConfigDir, _ = cmd.Flags().GetString("config-dir")
 
+			if onlyManaged, _ := cmd.Flags().GetBool("only-managed"); onlyManaged {
+				opts.Deep = true
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -281,7 +285,7 @@ func scanRun(opts *pkg.ScanOptions) error {
 	logrus.Debug("Checking for driftignore")
 	driftIgnore := filter.NewDriftIgnore(opts.DriftignorePath, opts.Driftignores...)
 
-	scanner := remote.NewScanner(remoteLibrary, alerter, remote.ScannerOptions{Deep: opts.Deep, OnlyManaged: opts.OnlyManaged}, driftIgnore)
+	scanner := remote.NewScanner(remoteLibrary, alerter, remote.ScannerOptions{Deep: opts.Deep}, driftIgnore)
 
 	iacSupplier, err := supplier.GetIACSupplier(opts.From, providerLibrary, opts.BackendOptions, iacProgress, alerter, resFactory, driftIgnore)
 	if err != nil {

--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -207,7 +207,7 @@ func (c Console) writeSummary(analysis *analyser.Analysis) {
 		if analysis.Summary().TotalDrifted > 0 {
 			drifted = errorWriter.Sprintf("%d", analysis.Summary().TotalDrifted)
 		}
-		if analysis.Options().Deep || analysis.Options().OnlyManaged {
+		if analysis.Options().Deep {
 			fmt.Printf("     - %s resource(s) out of sync with Terraform state\n", boldWriter.Sprintf("%s/%d", drifted, analysis.Summary().TotalManaged))
 		}
 

--- a/pkg/cmd/scan/output/console.go
+++ b/pkg/cmd/scan/output/console.go
@@ -207,7 +207,7 @@ func (c Console) writeSummary(analysis *analyser.Analysis) {
 		if analysis.Summary().TotalDrifted > 0 {
 			drifted = errorWriter.Sprintf("%d", analysis.Summary().TotalDrifted)
 		}
-		if analysis.Options().Deep {
+		if analysis.Options().Deep || analysis.Options().OnlyManaged {
 			fmt.Printf("     - %s resource(s) out of sync with Terraform state\n", boldWriter.Sprintf("%s/%d", drifted, analysis.Summary().TotalManaged))
 		}
 
@@ -215,13 +215,17 @@ func (c Console) writeSummary(analysis *analyser.Analysis) {
 		if analysis.Summary().TotalUnmanaged > 0 {
 			unmanaged = warningWriter.Sprintf("%d", analysis.Summary().TotalUnmanaged)
 		}
-		fmt.Printf(" - %s resource(s) not managed by Terraform\n", unmanaged)
+		if !analysis.Options().OnlyManaged {
+			fmt.Printf(" - %s resource(s) not managed by Terraform\n", unmanaged)
+		}
 
 		deleted := successWriter.Sprintf("0")
 		if analysis.Summary().TotalDeleted > 0 {
 			deleted = errorWriter.Sprintf("%d", analysis.Summary().TotalDeleted)
 		}
-		fmt.Printf(" - %s resource(s) found in a Terraform state but missing on the cloud provider\n", deleted)
+		if !analysis.Options().OnlyUnmanaged {
+			fmt.Printf(" - %s resource(s) found in a Terraform state but missing on the cloud provider\n", deleted)
+		}
 	}
 	if analysis.IsSync() {
 		fmt.Println(color.GreenString("Congrats! Your infrastructure is fully in sync."))

--- a/pkg/cmd/scan/output/console_test.go
+++ b/pkg/cmd/scan/output/console_test.go
@@ -114,6 +114,18 @@ func TestConsole_Write(t *testing.T) {
 			args:       args{analysis: fakeAnalysisWithoutDeep()},
 			wantErr:    false,
 		},
+		{
+			name:       "test console output with --only-managed",
+			goldenfile: "output_with_only_managed.txt",
+			args:       args{analysis: fakeAnalysisWithOnlyManagedFlag()},
+			wantErr:    false,
+		},
+		{
+			name:       "test console output with --only-unmanaged",
+			goldenfile: "output_with_only_unmanaged.txt",
+			args:       args{analysis: fakeAnalysisWithOnlyUnmanagedFlag()},
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -470,6 +470,7 @@ func fakeAnalysisWithOnlyManagedFlag() *analyser.Analysis {
 	a := analyser.Analysis{}
 	a.SetOptions(analyser.AnalyzerOptions{
 		OnlyManaged: true,
+		Deep:        true,
 	})
 	a.AddManaged(
 		&resource.Resource{

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snyk/driftctl/pkg/remote/common"
 	remoteerr "github.com/snyk/driftctl/pkg/remote/error"
 	"github.com/snyk/driftctl/pkg/resource"
+	"github.com/snyk/driftctl/pkg/resource/aws"
 )
 
 func fakeAnalysis(opts analyser.AnalyzerOptions) *analyser.Analysis {
@@ -457,6 +458,84 @@ func fakeAnalysisWithoutDeep() *analyser.Analysis {
 			Type: "aws_unmanaged_resource",
 			Attrs: &resource.Attributes{
 				"name": "First unmanaged resource",
+			},
+		},
+	)
+	a.ProviderName = "AWS"
+	a.ProviderVersion = "3.19.0"
+	return &a
+}
+
+func fakeAnalysisWithOnlyManagedFlag() *analyser.Analysis {
+	a := analyser.Analysis{}
+	a.SetOptions(analyser.AnalyzerOptions{
+		OnlyManaged: true,
+	})
+	a.AddManaged(
+		&resource.Resource{
+			Id:   "foo",
+			Type: aws.AwsInstanceResourceType,
+			Attrs: &resource.Attributes{
+				"instance_type": "test2",
+			},
+		},
+	)
+	a.AddDifference(
+		analyser.Difference{
+			Res: &resource.Resource{
+				Id:   "foo",
+				Type: aws.AwsInstanceResourceType,
+				Attrs: &resource.Attributes{
+					"instance_type": "test2",
+				},
+			},
+			Changelog: []analyser.Change{
+				{
+					Change: diff.Change{
+						Type: "update",
+						From: "test2",
+						To:   "test1",
+						Path: []string{
+							"instance_type",
+						},
+					},
+				},
+			},
+		})
+	a.AddDeleted(
+		&resource.Resource{
+			Id:   "baz",
+			Type: aws.AwsInstanceResourceType,
+			Attrs: &resource.Attributes{
+				"instance_type": "test3",
+			},
+		},
+	)
+	a.ProviderName = "AWS"
+	a.ProviderVersion = "3.19.0"
+	return &a
+}
+
+func fakeAnalysisWithOnlyUnmanagedFlag() *analyser.Analysis {
+	a := analyser.Analysis{}
+	a.SetOptions(analyser.AnalyzerOptions{
+		OnlyUnmanaged: true,
+	})
+	a.AddManaged(
+		&resource.Resource{
+			Id:   "foo",
+			Type: aws.AwsInstanceResourceType,
+			Attrs: &resource.Attributes{
+				"instance_type": "test2",
+			},
+		},
+	)
+	a.AddUnmanaged(
+		&resource.Resource{
+			Id:   "bar",
+			Type: aws.AwsInstanceResourceType,
+			Attrs: &resource.Attributes{
+				"instance_type": "test2",
 			},
 		},
 	)

--- a/pkg/cmd/scan/output/testdata/output_with_only_managed.txt
+++ b/pkg/cmd/scan/output/testdata/output_with_only_managed.txt
@@ -1,0 +1,10 @@
+Found missing resources:
+  - baz (aws_instance)
+Found changed resources:
+  - foo (aws_instance):
+      ~ instance_type: "test2" => "test1"
+Found 2 resource(s)
+ - 50% coverage
+ - 1 resource(s) managed by Terraform
+     - 1/1 resource(s) out of sync with Terraform state
+ - 1 resource(s) found in a Terraform state but missing on the cloud provider

--- a/pkg/cmd/scan/output/testdata/output_with_only_unmanaged.txt
+++ b/pkg/cmd/scan/output/testdata/output_with_only_unmanaged.txt
@@ -1,0 +1,7 @@
+Found resources not covered by IaC:
+  aws_instance:
+    - bar
+Found 2 resource(s)
+ - 50% coverage
+ - 1 resource(s) managed by Terraform
+ - 1 resource(s) not managed by Terraform

--- a/pkg/cmd/scan_test.go
+++ b/pkg/cmd/scan_test.go
@@ -52,6 +52,8 @@ func TestScanCmd_Valid(t *testing.T) {
 		{args: []string{"scan", "--driftignore", ".driftignore"}},
 		{args: []string{"scan", "-o", "html://result.html", "-o", "json://result.json"}},
 		{args: []string{"scan", "--tf-lockfile", "../.terraform.lock.hcl"}},
+		{args: []string{"scan", "--only-managed"}},
+		{args: []string{"scan", "--only-unmanaged"}},
 	}
 
 	for _, tt := range cases {

--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -35,6 +35,8 @@ type ScanOptions struct {
 	DriftignorePath  string
 	Driftignores     []string
 	Deep             bool
+	OnlyManaged      bool
+	OnlyUnmanaged    bool
 }
 
 type DriftCTL struct {

--- a/pkg/remote/scanner.go
+++ b/pkg/remote/scanner.go
@@ -13,8 +13,7 @@ import (
 )
 
 type ScannerOptions struct {
-	Deep        bool
-	OnlyManaged bool
+	Deep bool
 }
 
 type Scanner struct {
@@ -95,7 +94,7 @@ func (s *Scanner) scan() ([]*resource.Resource, error) {
 		return nil, err
 	}
 
-	if !s.options.Deep && !s.options.OnlyManaged {
+	if !s.options.Deep {
 		return enumerationResult, nil
 	}
 

--- a/pkg/remote/scanner.go
+++ b/pkg/remote/scanner.go
@@ -13,7 +13,8 @@ import (
 )
 
 type ScannerOptions struct {
-	Deep bool
+	Deep        bool
+	OnlyManaged bool
 }
 
 type Scanner struct {
@@ -94,7 +95,7 @@ func (s *Scanner) scan() ([]*resource.Resource, error) {
 		return nil, err
 	}
 
-	if !s.options.Deep {
+	if !s.options.Deep && !s.options.OnlyManaged {
 		return enumerationResult, nil
 	}
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | https://github.com/snyk/driftctl-docs/pull/223

## Description

This PR adds 2 new flags that will output a different summary at the end of the scan. 

The `--only-managed` flag should sum up what's under control only in your states:

```
Found missing resources:
  - vol-xxxx (aws_ebs_volume)
  From tfstate://terraform.tfstate
    - i-xxxxx (aws_instance.bar)
Found changed resources:
  From tfstate://terraform.tfstate
    - i-xxxxxx (aws_instance.foo):
        ~ instance_type: "t2.nano" => "t2.micro" (computed)
Found 4 resource(s)
 - 50% coverage
 - 2 resource(s) managed by Terraform
     - 1/2 resource(s) out of sync with Terraform state
 - 2 resource(s) found in a Terraform state but missing on the cloud provider
```

The `--only-unmanaged` flag should sum up what's NOT under control in your cloud provider:

```
Found resources not covered by IaC:
  aws_iam_policy_attachment:
    ....
  aws_iam_role:
    ....
  aws_iam_role_policy:
    ....
  aws_network_acl_rule:
    ....
Found 18 resource(s)
 - 11% coverage
 - 2 resource(s) managed by Terraform
 - 16 resource(s) not managed by Terraform
```

WARNING: I wonder if we should enforce to have only one of the three flags at a time `--only-managed` `--only-unmanaged` and `--deep`, once we agree on what I've coded.