### PR TITLE
Use voidprinter when sending HTML output to stdout

### DIFF
--- a/pkg/cmd/scan/output/output.go
+++ b/pkg/cmd/scan/output/output.go
@@ -89,6 +89,11 @@ func GetPrinter(config OutputConfig, quiet bool) output.Printer {
 			return &output.VoidPrinter{}
 		}
 		fallthrough
+	case HTMLOutputType:
+		if isStdOut(config.Path) {
+			return &output.VoidPrinter{}
+		}
+		fallthrough
 	case ConsoleOutputType:
 		fallthrough
 	default:

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -529,6 +529,18 @@ func TestGetPrinter(t *testing.T) {
 			key:  PlanOutputType,
 			want: &output.VoidPrinter{},
 		},
+		{
+			name: "html stdout output",
+			path: "stdout",
+			key:  HTMLOutputType,
+			want: &output.VoidPrinter{},
+		},
+		{
+			name: "html /dev/stdout output",
+			path: "/dev/stdout",
+			key:  HTMLOutputType,
+			want: &output.VoidPrinter{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1358
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

We should not print anything but the scan output when we send output to stdout.