### PR TITLE
chore: use jq to improve changelog script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
   release:
     resource_class: large
     docker:
-      - image: golang:1.17
+      - image: cimg/go:1.17
     steps:
       - checkout
       - gh/setup:


### PR DESCRIPTION
## Description

Small improvement of the changelog script.
I cannot resist to remove the dirty `sed` from #1361 

That add `jq` as a dependency, that's why I updated the build image to use the one provided by CircleCI with additional tooling within it.