### PR TITLE
Check for empty categories in changelog script

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -9,6 +9,10 @@ print_changelist() {
   shift
   list=("$@")
 
+  if [ ${#list[@]} -eq 0 ]; then
+    return
+  fi
+
   echo -e "$title"
   for change in "${list[@]}"; do
     echo "$change"
@@ -74,4 +78,4 @@ done
 print_changelist "## 🚀 Enhancements" "${enchancements[@]}"
 print_changelist "## 🐛 Bug Fixes" "${fixes[@]}"
 print_changelist "## 🔨 Maintenance" "${maintenance[@]}"
-print_changelist "## Uncategorised" "${uncategorised[@]}"
+print_changelist "## Other contributions" "${uncategorised[@]}"


### PR DESCRIPTION
## Description

This PR slightly improve the changelog generator script.

Since #1361, we don't check if categorised changes are empty, so it makes the changelog look like this : 

```md
## 🚀 Enhancements
- New --only-managed / --only-unmanaged flags (#1359) @wbeuil 
## 🐛 Bug Fixes
## 🔨 Maintenance
- Fix issue tagging script (#1362) @sundowndev 
- chore: fix failed ACC tests (#1363) @eliecharra 
## Uncategorised
```

But we want to filter out empty categories instead : 

```md
## 🚀 Enhancements
- New --only-managed / --only-unmanaged flags (#1359) @wbeuil
## 🔨 Maintenance
- Fix issue tagging script (#1362) @sundowndev
- chore: fix failed ACC tests (#1363) @eliecharra
```

I also renamed "Uncategorised" to "Other contributions", which I think is more explicit.