### PR TITLE
Add total_iac_source_count json field

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -27,11 +27,12 @@ type Difference struct {
 }
 
 type Summary struct {
-	TotalResources int `json:"total_resources"`
-	TotalDrifted   int `json:"total_changed"`
-	TotalUnmanaged int `json:"total_unmanaged"`
-	TotalDeleted   int `json:"total_missing"`
-	TotalManaged   int `json:"total_managed"`
+	TotalResources      int  `json:"total_resources"`
+	TotalDrifted        int  `json:"total_changed"`
+	TotalUnmanaged      int  `json:"total_unmanaged"`
+	TotalDeleted        int  `json:"total_missing"`
+	TotalManaged        int  `json:"total_managed"`
+	TotalIaCSourceCount uint `json:"total_iac_source_count"`
 }
 
 type Analysis struct {
@@ -166,6 +167,7 @@ func (a *Analysis) UnmarshalJSON(bytes []byte) error {
 	}
 	a.ProviderName = bla.ProviderName
 	a.ProviderVersion = bla.ProviderVersion
+	a.summary.TotalIaCSourceCount = bla.Summary.TotalIaCSourceCount
 	return nil
 }
 
@@ -206,6 +208,10 @@ func (a *Analysis) SetAlerts(alerts alerter.Alerts) {
 
 func (a *Analysis) SetOptions(options AnalyzerOptions) {
 	a.options = options
+}
+
+func (a *Analysis) SetIaCSourceCount(i uint) {
+	a.summary.TotalIaCSourceCount = i
 }
 
 func (a *Analysis) Coverage() int {

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -1270,6 +1270,7 @@ func addSchemaToRes(res *resource.Resource, repo resource.SchemaRepositoryInterf
 func TestAnalysis_MarshalJSON(t *testing.T) {
 	goldenFile := "./testdata/output.json"
 	analysis := Analysis{}
+	analysis.SetIaCSourceCount(1)
 	analysis.AddManaged(
 		&resource.Resource{
 			Id:   "AKIA5QYBVVD25KFXJHYJ",
@@ -1350,11 +1351,12 @@ func TestAnalysis_MarshalJSON(t *testing.T) {
 func TestAnalysis_UnmarshalJSON(t *testing.T) {
 	expected := Analysis{
 		summary: Summary{
-			TotalResources: 6,
-			TotalDrifted:   1,
-			TotalUnmanaged: 2,
-			TotalDeleted:   2,
-			TotalManaged:   2,
+			TotalResources:      6,
+			TotalDrifted:        1,
+			TotalUnmanaged:      2,
+			TotalDeleted:        2,
+			TotalManaged:        2,
+			TotalIaCSourceCount: 3,
 		},
 		managed: []*resource.Resource{
 			{
@@ -1431,6 +1433,7 @@ func TestAnalysis_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, 2, got.Summary().TotalDeleted)
 	assert.Equal(t, 6, got.Summary().TotalResources)
 	assert.Equal(t, 1, got.Summary().TotalDrifted)
+	assert.Equal(t, uint(3), got.Summary().TotalIaCSourceCount)
 	assert.Len(t, got.alerts, 1)
 	assert.Equal(t, got.alerts["aws_iam_access_key"][0].Message(), "This is an alert")
 }

--- a/pkg/analyser/testdata/input.json
+++ b/pkg/analyser/testdata/input.json
@@ -4,7 +4,8 @@
     "total_changed": 1,
     "total_unmanaged": 2,
     "total_missing": 2,
-    "total_managed": 2
+    "total_managed": 2,
+    "total_iac_source_count": 3
   },
   "managed": [
     {

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -4,7 +4,8 @@
 		"total_changed": 1,
 		"total_unmanaged": 2,
 		"total_missing": 2,
-		"total_managed": 2
+		"total_managed": 2,
+		"total_iac_source_count": 1
 	},
 	"managed": [
 		{

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -22,6 +22,7 @@ func fakeAnalysis(opts analyser.AnalyzerOptions) *analyser.Analysis {
 		opts = analyser.AnalyzerOptions{Deep: true}
 	}
 	a := analyser.NewAnalysis(opts)
+	a.SetIaCSourceCount(3)
 	a.AddUnmanaged(
 		&resource.Resource{
 			Id:   "unmanaged-id-1",

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -4,7 +4,8 @@
 		"total_changed": 2,
 		"total_unmanaged": 2,
 		"total_missing": 2,
-		"total_managed": 2
+		"total_managed": 2,
+		"total_iac_source_count": 3
 	},
 	"managed": [
 		{

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
@@ -4,7 +4,8 @@
 		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
-		"total_managed": 0
+		"total_managed": 0,
+		"total_iac_source_count": 0
 	},
 	"managed": null,
 	"unmanaged": null,

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
@@ -4,7 +4,8 @@
 		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
-		"total_managed": 0
+		"total_managed": 0,
+		"total_iac_source_count": 0
 	},
 	"managed": null,
 	"unmanaged": null,

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -4,7 +4,8 @@
 		"total_changed": 1,
 		"total_unmanaged": 0,
 		"total_missing": 0,
-		"total_managed": 1
+		"total_managed": 1,
+		"total_iac_source_count": 0
 	},
 	"managed": [
 		{

--- a/pkg/cmd/scan/output/testdata/output_multiples_times.json
+++ b/pkg/cmd/scan/output/testdata/output_multiples_times.json
@@ -4,7 +4,8 @@
 		"total_changed": 0,
 		"total_unmanaged": 0,
 		"total_missing": 0,
-		"total_managed": 0
+		"total_managed": 0,
+		"total_iac_source_count": 0
 	},
 	"managed": null,
 	"unmanaged": null,

--- a/pkg/driftctl.go
+++ b/pkg/driftctl.go
@@ -159,12 +159,14 @@ func (d DriftCTL) Run() (*analyser.Analysis, error) {
 		return nil, err
 	}
 
+	analysis.SetIaCSourceCount(d.iacSupplier.SourceCount())
 	analysis.Duration = time.Since(start)
 	analysis.Date = time.Now()
 
 	d.store.Bucket(memstore.TelemetryBucket).Set("total_resources", analysis.Summary().TotalResources)
 	d.store.Bucket(memstore.TelemetryBucket).Set("total_managed", analysis.Summary().TotalManaged)
 	d.store.Bucket(memstore.TelemetryBucket).Set("duration", uint(analysis.Duration.Seconds()+0.5))
+	d.store.Bucket(memstore.TelemetryBucket).Set("iac_source_count", d.iacSupplier.SourceCount())
 
 	return &analysis, nil
 }
@@ -192,7 +194,6 @@ func (d DriftCTL) scan() (remoteResources []*resource.Resource, resourcesFromSta
 	if err != nil {
 		return nil, nil, err
 	}
-	d.store.Bucket(memstore.TelemetryBucket).Set("iac_source_count", d.iacSupplier.SourceCount())
 
 	logrus.Info("Start scanning cloud provider")
 	d.scanProgress.Start()

--- a/pkg/driftctl_test.go
+++ b/pkg/driftctl_test.go
@@ -134,6 +134,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 			remoteResources: []*resource.Resource{},
 			assert: func(t *testing.T, result *test.ScanResult, err error) {
 				result.NotZero(result.Duration)
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 0, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -152,6 +153,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 			},
 			assert: func(t *testing.T, result *test.ScanResult, err error) {
 				result.AssertInfrastructureIsInSync()
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -171,6 +173,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 			remoteResources: []*resource.Resource{},
 			assert: func(t *testing.T, result *test.ScanResult, err error) {
 				result.AssertDeletedCount(1)
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -225,6 +228,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 					},
 					Computed: false,
 				})
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -264,6 +268,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 					},
 					Computed: true,
 				})
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -305,6 +310,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 					},
 					Computed: false,
 				})
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -346,6 +352,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 					},
 					Computed: false,
 				})
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -437,6 +444,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 				result.AssertUnmanagedCount(2)
 				result.AssertDeletedCount(0)
 				result.AssertDriftCountTotal(0)
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 4, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -534,6 +542,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 				result.AssertUnmanagedCount(4)
 				result.AssertDeletedCount(0)
 				result.AssertDriftCountTotal(0)
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 6, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))
@@ -633,6 +642,7 @@ func TestDriftctlRun_BasicBehavior(t *testing.T) {
 				result.AssertUnmanagedCount(1)
 				result.AssertDeletedCount(0)
 				result.AssertDriftCountTotal(0)
+				result.Equal(uint(2), result.Summary().TotalIaCSourceCount)
 			},
 			assertStore: func(t *testing.T, store memstore.Store) {
 				assert.Equal(t, 1, store.Bucket(memstore.TelemetryBucket).Get("total_resources"))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #1370
| ❓ Documentation  | https://github.com/snyk/driftctl-docs/pull/224 <!-- does this require documentation update ? -->

## Description

>  We should have the total number of sources scanned during the scan in the summary and output it our JSON format.

This PR adds a new JSON field to the scan output.