### PR TITLE
Add scan_duration json field

### DIFF
--- a/pkg/analyser/analysis.go
+++ b/pkg/analyser/analysis.go
@@ -64,6 +64,7 @@ type serializableAnalysis struct {
 	Alerts          map[string][]alerter.SerializableAlert `json:"alerts"`
 	ProviderName    string                                 `json:"provider_name"`
 	ProviderVersion string                                 `json:"provider_version"`
+	Duration        int                                    `json:"scan_duration"`
 }
 
 type GenDriftIgnoreOptions struct {
@@ -107,6 +108,7 @@ func (a Analysis) MarshalJSON() ([]byte, error) {
 	bla.Coverage = a.Coverage()
 	bla.ProviderName = a.ProviderName
 	bla.ProviderVersion = a.ProviderVersion
+	bla.Duration = int(a.Duration.Seconds())
 
 	return json.Marshal(bla)
 }
@@ -167,7 +169,8 @@ func (a *Analysis) UnmarshalJSON(bytes []byte) error {
 	}
 	a.ProviderName = bla.ProviderName
 	a.ProviderVersion = bla.ProviderVersion
-	a.summary.TotalIaCSourceCount = bla.Summary.TotalIaCSourceCount
+	a.SetIaCSourceCount(bla.Summary.TotalIaCSourceCount)
+	a.Duration = time.Duration(bla.Duration) * time.Second
 	return nil
 }
 

--- a/pkg/analyser/analyzer_test.go
+++ b/pkg/analyser/analyzer_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/pkg/filter"
 	"github.com/stretchr/testify/mock"
@@ -1269,7 +1270,9 @@ func addSchemaToRes(res *resource.Resource, repo resource.SchemaRepositoryInterf
 
 func TestAnalysis_MarshalJSON(t *testing.T) {
 	goldenFile := "./testdata/output.json"
-	analysis := Analysis{}
+	analysis := Analysis{
+		Duration: 241 * time.Second,
+	}
 	analysis.SetIaCSourceCount(1)
 	analysis.AddManaged(
 		&resource.Resource{

--- a/pkg/analyser/testdata/output.json
+++ b/pkg/analyser/testdata/output.json
@@ -70,5 +70,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "2.18.5"
+	"provider_version": "2.18.5",
+	"scan_duration": 241
 }

--- a/pkg/cmd/scan/output/output_test.go
+++ b/pkg/cmd/scan/output/output_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/r3labs/diff/v2"
@@ -23,6 +24,7 @@ func fakeAnalysis(opts analyser.AnalyzerOptions) *analyser.Analysis {
 	}
 	a := analyser.NewAnalysis(opts)
 	a.SetIaCSourceCount(3)
+	a.Duration = 12 * time.Second
 	a.AddUnmanaged(
 		&resource.Resource{
 			Id:   "unmanaged-id-1",

--- a/pkg/cmd/scan/output/testdata/output.json
+++ b/pkg/cmd/scan/output/testdata/output.json
@@ -107,5 +107,6 @@
 	"coverage": 33,
 	"alerts": null,
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"scan_duration": 12
 }

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_aws.json
@@ -26,5 +26,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"scan_duration": 0
 }

--- a/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
+++ b/pkg/cmd/scan/output/testdata/output_access_denied_alert_github.json
@@ -23,5 +23,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"scan_duration": 0
 }

--- a/pkg/cmd/scan/output/testdata/output_computed_fields.json
+++ b/pkg/cmd/scan/output/testdata/output_computed_fields.json
@@ -91,5 +91,6 @@
 		]
 	},
 	"provider_name": "AWS",
-	"provider_version": "3.19.0"
+	"provider_version": "3.19.0",
+	"scan_duration": 0
 }

--- a/pkg/cmd/scan/output/testdata/output_multiples_times.json
+++ b/pkg/cmd/scan/output/testdata/output_multiples_times.json
@@ -14,5 +14,6 @@
 	"coverage": 0,
 	"alerts": null,
 	"provider_name": "",
-	"provider_version": ""
+	"provider_version": "",
+	"scan_duration": 0
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | https://github.com/snyk/driftctl/issues/1369
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

>  We want to be able to retrieve the scan duration from the analysis and output it in the JSON output.

This PR adds a new JSON field to the scan output.