### PR TITLE
Fix panic in apigatewayv2_api_mapping enumerator

### DIFF
--- a/pkg/remote/aws/apigatewayv2_mapping_enumerator.go
+++ b/pkg/remote/aws/apigatewayv2_mapping_enumerator.go
@@ -38,15 +38,21 @@ func (e *ApiGatewayV2MappingEnumerator) Enumerate() ([]*resource.Resource, error
 			return nil, remoteerror.NewResourceListingError(err, string(e.SupportedType()))
 		}
 		for _, mapping := range mappings {
+			attrs := make(map[string]interface{})
+
+			if mapping.ApiId != nil {
+				attrs["api_id"] = *mapping.ApiId
+			}
+			if mapping.Stage != nil {
+				attrs["stage"] = *mapping.Stage
+			}
+
 			results = append(
 				results,
 				e.factory.CreateAbstractResource(
 					string(e.SupportedType()),
 					*mapping.ApiMappingId,
-					map[string]interface{}{
-						"stage":  *mapping.Stage,
-						"api_id": *mapping.ApiId,
-					},
+					attrs,
 				),
 			)
 		}

--- a/pkg/resource/aws/aws_apigatewayv2_mapping.go
+++ b/pkg/resource/aws/aws_apigatewayv2_mapping.go
@@ -8,10 +8,16 @@ func initAwsApiGatewayV2MappingMetaData(resourceSchemaRepository resource.Schema
 	resourceSchemaRepository.SetHumanReadableAttributesFunc(
 		AwsApiGatewayV2MappingResourceType,
 		func(res *resource.Resource) map[string]string {
-			return map[string]string{
-				"Api":   *res.Attributes().GetString("api_id"),
-				"Stage": *res.Attributes().GetString("stage"),
+			attrs := make(map[string]string)
+
+			if v := res.Attributes().GetString("api_id"); v != nil {
+				attrs["Api"] = *v
 			}
+			if v := res.Attributes().GetString("stage"); v != nil {
+				attrs["Stage"] = *v
+			}
+
+			return attrs
 		},
 	)
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | yes
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no <!-- does this require documentation update ? -->

## Description

User on Discord recently reported a crash happening while scanning cloud resources. [Stack trace in crash report](https://sentry.io/organizations/snyk/issues/3079840329/?project=5568568&query=is%3Aunresolved) showed that it's the `apigatewayv2_mapping` enumerator using `nil` as values for `stage` and `api_id`.

### Stack trace

```
*errors.fundamental: A runner routine paniced: runtime error: invalid memory address or nil pointer dereference
  File "/root/project/pkg/parallel/parallel_runner.go", line 94, in (*ParallelRunner).Run.func1.1
  File "/root/project/pkg/remote/aws/apigatewayv2_mapping_enumerator.go", line 47, in (*ApiGatewayV2MappingEnumerator).Enumerate
  File "/root/project/pkg/remote/scanner.go", line 71, in (*Scanner).scan.func1
  File "/root/project/pkg/parallel/parallel_runner.go", line 97, in (*ParallelRunner).Run.func1
```