### PR TITLE
fix: change instance class for the rds cluster

### DIFF
--- a/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/terraform.tf
+++ b/pkg/resource/aws/testdata/acc/aws_rds_cluster_instance/terraform.tf
@@ -24,7 +24,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count              = 2
   identifier         = "aurora-cluster-demo-${count.index}"
   cluster_identifier = aws_rds_cluster.postgresql.id
-  instance_class     = "db.r4.large"
+  instance_class     = "db.r5.large"
   engine             = aws_rds_cluster.postgresql.engine
   engine_version     = aws_rds_cluster.postgresql.engine_version
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

Acceptance tests were failing the past 2-3 days because of a wrong configuration of instance class for rds.

`db.r4.large` instance class can't be associated with Postgre 13 versions as per this screenshot

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/8110579/158184221-d28e6be7-8a4c-460c-9c22-2926b43a559a.png">
