### PR TITLE
test: route53 name parsing

### DIFF
--- a/pkg/remote/aws_route53_scanner_test.go
+++ b/pkg/remote/aws_route53_scanner_test.go
@@ -324,7 +324,7 @@ func TestRoute53_Record(t *testing.T) {
 						Type: awssdk.String("A"),
 					},
 					{
-						Name: awssdk.String("*.test4."),
+						Name: awssdk.String("\\052.test4."),
 						Type: awssdk.String("A"),
 					},
 				}, nil)


### PR DESCRIPTION
## Description

This PR bring a light change to the AWS scanner tests. The name parsing for route53 records were not really relevant since it didn't test the new behavior.