### PR TITLE
[CFG-1601] Add blobs config to goreleaser file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,3 +39,8 @@ checksum:
     algorithm: sha256
 snapshot:
     name_template: "{{ .Tag }}-next"
+blobs:
+    - provider: s3
+      bucket: snyk-assets
+      region: us-east-1
+      folder: "cli/driftctl/{{.Tag}}"


### PR DESCRIPTION
## Description

> It would be good to serve DriftCtl binary from [static.snyk.io](http://static.snyk.io/) and have the Snyk CLI download it from there.

This PR adds a config option to upload release artifacts to the `snyk-assets` S3 bucket.