### PR TITLE
Fix issue parsing in issue tagging script

### DIFF
--- a/scripts/issue-tagging.sh
+++ b/scripts/issue-tagging.sh
@@ -28,6 +28,8 @@ if ! $GHCLI_BIN auth status &> /dev/null; then
     exit 1
 fi
 
+echo "Finding merged pull requests between $BASE_TAG and $LATEST_TAG..."
+
 # Compare $BASE_TAG branch with the latest tag
 # Keep IDs of merged pull requests
 PRs=$(git log --pretty=oneline "$BASE_TAG"..."$LATEST_TAG" | grep 'Merge pull request #' | grep -oE '#[0-9]+' | sed 's/#//')
@@ -47,6 +49,10 @@ for pr in $PRs; do
     fi
     ISSUES+=("$id")
 done
+
+# Remove duplicate IDs
+# This can happen when we release using a separate branch (e.g. patch releases)
+mapfile -t ISSUES < <(printf "%s\n" "${ISSUES[@]}" | sort -u)
 
 echo "Creating milestone $LATEST_TAG in github.com/$REPO"
 curl -X POST \

--- a/scripts/issue-tagging.sh
+++ b/scripts/issue-tagging.sh
@@ -36,7 +36,7 @@ PRs=$(git log --pretty=oneline "$BASE_TAG"..."$LATEST_TAG" | grep 'Merge pull re
 EXIT_CODE=0
 ISSUES=()
 for pr in $PRs; do
-    id=$($GHCLI_BIN pr view "$pr" --json body | grep -oE 'Related issues | (.*)?[0-9]+(.*)?\|' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g' || true)
+    id=$($GHCLI_BIN pr view "$pr" --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g' || true)
     if [ -z "$id" ]; then
         continue
     fi


### PR DESCRIPTION
## Description

**chore: remove duplicates in array**

Added a line to remove duplicates entries in the ISSUES variable. This can happen when we compare two branches where merge commits were cherry-picked (e.g. patch releases).

**chore: fix issue parsing in issue tagging script**

Following https://github.com/snyk/driftctl/pull/1444, this PR fixes the regex that parses the issue identifier in pull requests.

Example:

```bash
$ gh pr view 1443 --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g'
$ gh pr view 1379 --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g'
998%
$ gh pr view 1444 --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g'
$ gh pr view 1371 --json body | grep -oE '(Related issues \| )(.*)?[0-9]+(.*|\r|\n)?(\|)' | sed 's/[^[:digit:]]//g' | sed -z 's/\n//g'
1370%                                                                                               
```

See [failed job](https://app.circleci.com/pipelines/github/snyk/driftctl/4378/workflows/be45eb7d-4754-4b26-8775-a015f6b223be/jobs/9819).