### PR TITLE
Remove hint from the diagnostic output

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -345,8 +345,6 @@ func scanRun(opts *pkg.ScanOptions) error {
 	}
 
 	if !analysis.IsSync() {
-		globaloutput.Printf("\nHint: use gen-driftignore command to generate a .driftignore file based on your drifts\n")
-
 		return cmderrors.InfrastructureNotInSync{}
 	}
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | none
| ❓ Documentation  | no

## Description

We have decided to remove hint from there since they do not make sense anymore when displayed under Snyk CLI.
Another option could be to introduce a `--no-hint` flag or maybe reuse the actual `--quiet` flag.
Wrapping that in the `--quiet` flag have the drawback of loosing the progress bar and other useful diagnostic messages.
