### PR TITLE
Change code ownership to a more accurate team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/group-infrastructure-as-code
+* @snyk/iac-code-to-cloud


### PR DESCRIPTION
## Description

I think it can make sense to move the ownership of driftctl from the group to the team.
It will allow PR auto assign to be more accurate 🙏🏻
I'm not sure about the meaning for Snyk, I'll be sad but feel free to discard if it's not relevant.