### PR TITLE
State discovery for Terraform cloud

### DIFF
--- a/pkg/cmd/scan.go
+++ b/pkg/cmd/scan.go
@@ -404,10 +404,18 @@ func retrieveBackendsFromHCL(workdir string) ([]config.SupplierConfig, error) {
 			continue
 		}
 
+		var cfg *config.SupplierConfig
 		ws := hcl.GetCurrentWorkspaceName(path.Dir(match))
-		if supplierConfig := body.Backend.SupplierConfig(ws); supplierConfig != nil {
-			globaloutput.Printf(color.WhiteString("Using Terraform state %s found in %s. Use the --from flag to specify another state file.\n"), supplierConfig, match)
-			supplierConfigs = append(supplierConfigs, *supplierConfig)
+
+		if body.Cloud != nil {
+			cfg = body.Cloud.SupplierConfig(ws)
+		}
+		if body.Backend != nil {
+			cfg = body.Backend.SupplierConfig(ws)
+		}
+		if cfg != nil {
+			globaloutput.Printf(color.WhiteString("Using Terraform state %s found in %s. Use the --from flag to specify another state file.\n"), cfg, match)
+			supplierConfigs = append(supplierConfigs, *cfg)
 		}
 	}
 

--- a/pkg/terraform/hcl/backend_test.go
+++ b/pkg/terraform/hcl/backend_test.go
@@ -8,32 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHCL_getCurrentWorkspaceName(t *testing.T) {
-	cases := []struct {
-		name string
-		dir  string
-		want string
-	}{
-		{
-			name: "test with non-default workspace",
-			dir:  "testdata/foo_workspace",
-			want: "foo",
-		},
-		{
-			name: "test with non-existing directory",
-			dir:  "testdata/noenvfile",
-			want: "default",
-		},
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			workspace := GetCurrentWorkspaceName(tt.dir)
-			assert.Equal(t, tt.want, workspace)
-		})
-	}
-}
-
 func TestBackend_SupplierConfig(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -45,7 +19,6 @@ func TestBackend_SupplierConfig(t *testing.T) {
 			name:     "test with no backend block",
 			filename: "testdata/no_backend_block.tf",
 			want:     nil,
-			wantErr:  "testdata/no_backend_block.tf:1,11-11: Missing backend block; A backend block is required.",
 		},
 		{
 			name:     "test with local backend block",
@@ -118,7 +91,7 @@ func TestBackend_SupplierConfig(t *testing.T) {
 			}
 
 			ws := GetCurrentWorkspaceName(path.Dir(tt.filename))
-			if hcl.Backend.SupplierConfig(ws) == nil {
+			if hcl.Backend == nil || hcl.Backend.SupplierConfig(ws) == nil {
 				assert.Nil(t, tt.want)
 				return
 			}

--- a/pkg/terraform/hcl/cloud.go
+++ b/pkg/terraform/hcl/cloud.go
@@ -10,8 +10,9 @@ import (
 )
 
 type CloudWorkspacesBlock struct {
-	Name string   `hcl:"name,optional"`
-	Tags []string `hcl:"tags,optional"`
+	Name   string   `hcl:"name,optional"`
+	Tags   []string `hcl:"tags,optional"`
+	Remain hcl.Body `hcl:",remain"`
 }
 
 type CloudBlock struct {

--- a/pkg/terraform/hcl/cloud.go
+++ b/pkg/terraform/hcl/cloud.go
@@ -1,0 +1,33 @@
+package hcl
+
+import (
+	"path"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/snyk/driftctl/pkg/iac/config"
+	"github.com/snyk/driftctl/pkg/iac/terraform/state"
+	"github.com/snyk/driftctl/pkg/iac/terraform/state/backend"
+)
+
+type CloudWorkspacesBlock struct {
+	Name string   `hcl:"name,optional"`
+	Tags []string `hcl:"tags,optional"`
+}
+
+type CloudBlock struct {
+	Organization string               `hcl:"organization"`
+	Workspaces   CloudWorkspacesBlock `hcl:"workspaces,block"`
+	Remain       hcl.Body             `hcl:",remain"`
+}
+
+func (c CloudBlock) SupplierConfig(workspace string) *config.SupplierConfig {
+	// If a workspace is specified in HCL, use it rather than the current environment
+	if c.Workspaces.Name != "" {
+		workspace = c.Workspaces.Name
+	}
+	return &config.SupplierConfig{
+		Key:     state.TerraformStateReaderSupplier,
+		Backend: backend.BackendKeyTFCloud,
+		Path:    path.Join(c.Organization, workspace),
+	}
+}

--- a/pkg/terraform/hcl/cloud_test.go
+++ b/pkg/terraform/hcl/cloud_test.go
@@ -1,0 +1,55 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/snyk/driftctl/pkg/iac/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloud_SupplierConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		filename string
+		want     *config.SupplierConfig
+		wantErr  string
+	}{
+		{
+			name:     "test with cloud block and default workspace",
+			filename: "testdata/cloud_block.tf",
+			want: &config.SupplierConfig{
+				Key:     "tfstate",
+				Backend: "tfcloud",
+				Path:    "example_corp/default",
+			},
+		},
+		{
+			name:     "test with cloud block and non-default workspace",
+			filename: "testdata/cloud_block_workspace.tf",
+			want: &config.SupplierConfig{
+				Key:     "tfstate",
+				Backend: "tfcloud",
+				Path:    "example_corp/my-workspace",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			hcl, err := ParseTerraformFromHCL(tt.filename)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			if hcl.Cloud == nil {
+				assert.Nil(t, tt.want)
+				return
+			}
+
+			assert.Equal(t, *tt.want, *hcl.Cloud.SupplierConfig("default"))
+		})
+	}
+}

--- a/pkg/terraform/hcl/hcl.go
+++ b/pkg/terraform/hcl/hcl.go
@@ -18,8 +18,9 @@ type MainBodyBlock struct {
 }
 
 type TerraformBlock struct {
-	Backend BackendBlock `hcl:"backend,block"`
-	Remain  hcl.Body     `hcl:",remain"`
+	Backend *BackendBlock `hcl:"backend,block"`
+	Cloud   *CloudBlock   `hcl:"cloud,block"`
+	Remain  hcl.Body      `hcl:",remain"`
 }
 
 func ParseTerraformFromHCL(filename string) (*TerraformBlock, error) {

--- a/pkg/terraform/hcl/hcl_test.go
+++ b/pkg/terraform/hcl/hcl_test.go
@@ -1,0 +1,33 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHCL_getCurrentWorkspaceName(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{
+			name: "test with non-default workspace",
+			dir:  "testdata/foo_workspace",
+			want: "foo",
+		},
+		{
+			name: "test with non-existing directory",
+			dir:  "testdata/noenvfile",
+			want: "default",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			workspace := GetCurrentWorkspaceName(tt.dir)
+			assert.Equal(t, tt.want, workspace)
+		})
+	}
+}

--- a/pkg/terraform/hcl/testdata/cloud_block.tf
+++ b/pkg/terraform/hcl/testdata/cloud_block.tf
@@ -1,0 +1,8 @@
+terraform {
+    cloud {
+        organization = "example_corp"
+        hostname = "app.terraform.io" # Optional; defaults to app.terraform.io
+
+        workspaces {}
+    }
+}

--- a/pkg/terraform/hcl/testdata/cloud_block_workspace.tf
+++ b/pkg/terraform/hcl/testdata/cloud_block_workspace.tf
@@ -1,0 +1,10 @@
+terraform {
+    cloud {
+        organization = "example_corp"
+        hostname = "app.terraform.io" # Optional; defaults to app.terraform.io
+
+        workspaces {
+            name = "my-workspace"
+        }
+    }
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | yes
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | [CTX-331](https://snyksec.atlassian.net/browse/CTX-331)
| ❓ Documentation  | https://github.com/snyk/driftctl-docs/pull/247 <!-- does this require documentation update ? -->

## Description

This PR adds state discovery for terraform cloud backend. This was tested with a TFC workspace, using both named and tag-targeted configurations.

**What changed**
- Moved `TestHCL_getCurrentWorkspaceName` test suite to `hcl_test.go` with no changes
- Added support for Cloud block in schema
- The backend block in HCL is not required anymore since Cloud and Backend are mutually exclusive

**Notes for the reviewers**
- Should we rename the terraform/hcl package to a more relevant name ? I think hcl is a bit too generic for such a specific logic