### PR TITLE
Fix CODEOWNERS team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/iac-code-to-cloud
+* @snyk/cloud-context


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | no

## Description

https://github.com/snyk/driftctl/blob/main/.github/CODEOWNERS was showing "this codeowners file contains errors". ~~I think it all still works, presumably redirecting to https://github.com/orgs/snyk/teams/cloud-context, but this is a fix for a very minor broken window.~~

Nope, the auto-assignment _doesn't_ work, presumably because of the broken codeowners name!