### PR TITLE
chore: Retry route table association test

### DIFF
--- a/pkg/resource/aws/aws_route_table_association_test.go
+++ b/pkg/resource/aws/aws_route_table_association_test.go
@@ -2,6 +2,7 @@ package aws_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/snyk/driftctl/test"
 	"github.com/snyk/driftctl/test/acceptance"
@@ -17,6 +18,7 @@ func TestAcc_Aws_RouteTableAssociation(t *testing.T) {
 				Env: map[string]string{
 					"AWS_REGION": "us-east-1",
 				},
+				ShouldRetry: acceptance.LinearBackoff(10 * time.Minute),
 				Check: func(result *test.ScanResult, stdout string, err error) {
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
## Description

We've been seeing consistent failures for that resource, adding a retry.