### PR TITLE
Can you guys fix your issues tab?

### DIFF
--- a/fix_issues_tab.txt
+++ b/fix_issues_tab.txt
@@ -1,0 +1,2 @@
+placeholder
+


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| 🐛 Bug fix?       | no
| 🚀 New feature?   | no
| ⚠ Deprecations?   | no
| ❌ BC Break       | no
| 🔗 Related issues | #...
| ❓ Documentation  | yes <!-- does this require documentation update ? -->

## Description

Your issues tab in Github is currently missing, but it is indexed in Google. Could you please add it back? We're trying to understand a particular message output by driftctl and an existing issue might be helpful. If for some reason you don't want an issues tab, could you elaborate on why and where to go for problems like these?

<img width="727" alt="image" src="https://github.com/snyk/driftctl/assets/5428143/4e023824-b5e2-4c24-8959-7f4e17fd7e8a">
